### PR TITLE
Publish Docker images for release tags

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read
@@ -39,8 +42,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}
           tags: |
-            type=raw,value=pr-${{ github.event.pull_request.number }}
-            type=sha,prefix=pr-${{ github.event.pull_request.number }}-
+            type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
+            type=sha,prefix=pr-${{ github.event.pull_request.number }}-,enable=${{ github.event_name == 'pull_request' }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Extract Docker metadata for frontend
         id: frontend_meta
@@ -48,8 +53,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
           tags: |
-            type=raw,value=pr-${{ github.event.pull_request.number }}
-            type=sha,prefix=pr-${{ github.event.pull_request.number }}-
+            type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
+            type=sha,prefix=pr-${{ github.event.pull_request.number }}-,enable=${{ github.event_name == 'pull_request' }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and publish backend image
         uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Pull requests targeting `main` publish Docker images to GitHub Container Registr
 - `ghcr.io/alexpoty/pizzalab/backend:pr-<number>`
 - `ghcr.io/alexpoty/pizzalab/frontend:pr-<number>`
 
+Release tags also publish versioned images. For example, pushing `v0.1.0` publishes:
+
+- `ghcr.io/alexpoty/pizzalab/backend:0.1.0`
+- `ghcr.io/alexpoty/pizzalab/backend:latest`
+- `ghcr.io/alexpoty/pizzalab/frontend:0.1.0`
+- `ghcr.io/alexpoty/pizzalab/frontend:latest`
+
+Run a release image:
+
+```bash
+IMAGE_TAG=0.1.0 docker compose -f docker-compose.ghcr.yml up
+```
+
 Planned first endpoint:
 
 ```http


### PR DESCRIPTION
Extends the Docker image publishing workflow to publish versioned and latest GHCR images when release tags like v0.1.0 or v0.2.0 are pushed.