### PR TITLE
Add recipe load, edit, and duplicate flow

### DIFF
--- a/backend/src/main/kotlin/com/pizzalab/backend/api/common/ApiExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/pizzalab/backend/api/common/ApiExceptionHandler.kt
@@ -1,11 +1,13 @@
 package com.pizzalab.backend.api.common
 
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.server.ResponseStatusException
 
 @RestControllerAdvice
 class ApiExceptionHandler {
@@ -36,5 +38,12 @@ class ApiExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     fun handleUnreadableMessage(exception: HttpMessageNotReadableException): ApiErrorResponse {
         return ApiErrorResponse("Invalid request payload.")
+    }
+
+    @ExceptionHandler(ResponseStatusException::class)
+    fun handleResponseStatusException(exception: ResponseStatusException): ResponseEntity<ApiErrorResponse> {
+        return ResponseEntity
+            .status(exception.statusCode)
+            .body(ApiErrorResponse(exception.reason ?: "Request failed."))
     }
 }

--- a/backend/src/main/kotlin/com/pizzalab/backend/api/common/ApiExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/pizzalab/backend/api/common/ApiExceptionHandler.kt
@@ -11,18 +11,12 @@ import org.springframework.web.server.ResponseStatusException
 
 @RestControllerAdvice
 class ApiExceptionHandler {
-    /**
-     * Converts domain validation failures into HTTP 400 responses.
-     */
     @ExceptionHandler(IllegalArgumentException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     fun handleIllegalArgumentException(exception: IllegalArgumentException): ApiErrorResponse {
         return ApiErrorResponse(exception.message ?: "Invalid request.")
     }
 
-    /**
-     * Converts Jakarta Bean Validation failures into HTTP 400 responses.
-     */
     @ExceptionHandler(MethodArgumentNotValidException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     fun handleValidationException(exception: MethodArgumentNotValidException): ApiErrorResponse {
@@ -31,12 +25,9 @@ class ApiExceptionHandler {
         return ApiErrorResponse(message)
     }
 
-    /**
-     * Converts malformed JSON and enum parsing failures into HTTP 400 responses.
-     */
     @ExceptionHandler(HttpMessageNotReadableException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    fun handleUnreadableMessage(exception: HttpMessageNotReadableException): ApiErrorResponse {
+    fun handleUnreadableMessage(@Suppress("UNUSED_PARAMETER") exception: HttpMessageNotReadableException): ApiErrorResponse {
         return ApiErrorResponse("Invalid request payload.")
     }
 

--- a/backend/src/main/kotlin/com/pizzalab/backend/api/recipe/RecipeController.kt
+++ b/backend/src/main/kotlin/com/pizzalab/backend/api/recipe/RecipeController.kt
@@ -21,33 +21,21 @@ import java.util.UUID
 class RecipeController(
     private val recipeManagement: RecipeManagementUseCase,
 ) {
-    /**
-     * HTTP adapter for saving the current calculator input under a user-provided name.
-     */
     @PostMapping
     fun create(@Valid @RequestBody request: CreateRecipeRequest): RecipeResponse {
         return recipeManagement.create(request)
     }
 
-    /**
-     * Replaces an existing saved recipe while preserving its identity for future loads.
-     */
     @PutMapping("/{id}")
     fun update(@PathVariable id: UUID, @Valid @RequestBody request: CreateRecipeRequest): RecipeResponse {
         return recipeManagement.update(id, request)
     }
 
-    /**
-     * Returns saved recipes newest-first so recent formulas stay easy to reuse.
-     */
     @GetMapping
     fun list(): List<RecipeResponse> {
         return recipeManagement.list()
     }
 
-    /**
-     * Deletes a recipe by id. Deleting an already-missing id is intentionally idempotent.
-     */
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun delete(@PathVariable id: UUID) {

--- a/backend/src/main/kotlin/com/pizzalab/backend/api/recipe/RecipeController.kt
+++ b/backend/src/main/kotlin/com/pizzalab/backend/api/recipe/RecipeController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -26,6 +27,14 @@ class RecipeController(
     @PostMapping
     fun create(@Valid @RequestBody request: CreateRecipeRequest): RecipeResponse {
         return recipeManagement.create(request)
+    }
+
+    /**
+     * Replaces an existing saved recipe while preserving its identity for future loads.
+     */
+    @PutMapping("/{id}")
+    fun update(@PathVariable id: UUID, @Valid @RequestBody request: CreateRecipeRequest): RecipeResponse {
+        return recipeManagement.update(id, request)
     }
 
     /**

--- a/backend/src/main/kotlin/com/pizzalab/backend/application/RecipeManagementUseCase.kt
+++ b/backend/src/main/kotlin/com/pizzalab/backend/application/RecipeManagementUseCase.kt
@@ -4,44 +4,45 @@ import com.pizzalab.backend.api.dough.toFormula
 import com.pizzalab.backend.api.recipe.dto.CreateRecipeRequest
 import com.pizzalab.backend.api.recipe.dto.RecipeResponse
 import com.pizzalab.backend.persistence.recipe.RecipeJdbcRepository
+import com.pizzalab.backend.persistence.recipe.RecipeRecord
 import com.pizzalab.backend.persistence.recipe.toRecord
 import com.pizzalab.backend.persistence.recipe.toResponse
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
-import org.springframework.http.HttpStatus
 import java.util.UUID
 
 @Service
 class RecipeManagementUseCase(
     private val recipeRepository: RecipeJdbcRepository,
 ) {
-    /**
-     * Coordinates recipe persistence without exposing JDBC details to the HTTP layer.
-     */
     fun create(request: CreateRecipeRequest): RecipeResponse {
-        request.formula.toFormula()
+        validateFormula(request)
         return recipeRepository.save(request.toRecord()).toResponse()
     }
 
     fun update(id: UUID, request: CreateRecipeRequest): RecipeResponse {
-        request.formula.toFormula()
-        val existingRecipe = recipeRepository.findById(id).orElseThrow {
-            ResponseStatusException(HttpStatus.NOT_FOUND, "Recipe not found.")
-        }
+        validateFormula(request)
+        val existingRecipe = findRecipeOrThrow(id)
         return recipeRepository.save(request.toRecord(existingRecipe)).toResponse()
     }
 
-    /**
-     * Lists recipes in presentation order. The repository owns the database ordering detail.
-     */
     fun list(): List<RecipeResponse> {
         return recipeRepository.findAllByOrderByCreatedAtDesc().map { it.toResponse() }
     }
 
-    /**
-     * Keeps delete semantics simple for clients: repeated deletes do not fail.
-     */
     fun delete(id: UUID) {
         recipeRepository.deleteById(id)
+    }
+
+    private fun validateFormula(request: CreateRecipeRequest) {
+        // Recipe writes should fail with the same validation rules as live calculations.
+        request.formula.toFormula()
+    }
+
+    private fun findRecipeOrThrow(id: UUID): RecipeRecord {
+        return recipeRepository.findById(id).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "Recipe not found.")
+        }
     }
 }

--- a/backend/src/main/kotlin/com/pizzalab/backend/application/RecipeManagementUseCase.kt
+++ b/backend/src/main/kotlin/com/pizzalab/backend/application/RecipeManagementUseCase.kt
@@ -7,6 +7,8 @@ import com.pizzalab.backend.persistence.recipe.RecipeJdbcRepository
 import com.pizzalab.backend.persistence.recipe.toRecord
 import com.pizzalab.backend.persistence.recipe.toResponse
 import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.http.HttpStatus
 import java.util.UUID
 
 @Service
@@ -19,6 +21,14 @@ class RecipeManagementUseCase(
     fun create(request: CreateRecipeRequest): RecipeResponse {
         request.formula.toFormula()
         return recipeRepository.save(request.toRecord()).toResponse()
+    }
+
+    fun update(id: UUID, request: CreateRecipeRequest): RecipeResponse {
+        request.formula.toFormula()
+        val existingRecipe = recipeRepository.findById(id).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "Recipe not found.")
+        }
+        return recipeRepository.save(request.toRecord(existingRecipe)).toResponse()
     }
 
     /**

--- a/backend/src/main/kotlin/com/pizzalab/backend/persistence/recipe/RecipeRecordMapper.kt
+++ b/backend/src/main/kotlin/com/pizzalab/backend/persistence/recipe/RecipeRecordMapper.kt
@@ -12,11 +12,8 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
-/**
- * Converts API recipe input into the relational shape stored by Spring Data JDBC.
- */
 fun CreateRecipeRequest.toRecord(): RecipeRecord {
-    return toRecord(
+    return toRecipeRecord(
         recipeId = UUID.randomUUID(),
         createdAt = OffsetDateTime.now(ZoneOffset.UTC),
         isNew = true,
@@ -24,34 +21,35 @@ fun CreateRecipeRequest.toRecord(): RecipeRecord {
 }
 
 fun CreateRecipeRequest.toRecord(existingRecord: RecipeRecord): RecipeRecord {
-    return toRecord(
+    return toRecipeRecord(
         recipeId = existingRecord.id,
         createdAt = existingRecord.createdAt,
         isNew = false,
     )
 }
 
-/**
- * Converts stored rows back into the same formula contract used by the calculator API.
- */
 fun RecipeRecord.toResponse(): RecipeResponse {
     return RecipeResponse(
         id = id,
         name = name,
-        formula = DoughCalculationRequest(
-            pizzaCount = pizzaCount,
-            doughBallWeightGrams = doughBallWeightGrams.toDouble(),
-            hydrationPercent = hydrationPercent.toDouble(),
-            saltPercent = saltPercent.toDouble(),
-            yeastType = YeastType.valueOf(yeastType),
-            doughMethod = DoughMethod.valueOf(doughMethod),
-            fermentationSchedule = toFermentationScheduleRequest(),
-            fermentationPreset = fermentationPreset?.let { FermentationPreset.valueOf(it) },
-            roomTemperatureCelsius = roomTemperatureCelsius?.toDouble(),
-            coldTemperatureCelsius = coldTemperatureCelsius?.toDouble(),
-            prefermentFlourPercent = prefermentFlourPercent?.toDouble(),
-        ),
+        formula = toFormulaRequest(),
         createdAt = createdAt.toInstant(),
+    )
+}
+
+private fun RecipeRecord.toFormulaRequest(): DoughCalculationRequest {
+    return DoughCalculationRequest(
+        pizzaCount = pizzaCount,
+        doughBallWeightGrams = doughBallWeightGrams.toDouble(),
+        hydrationPercent = hydrationPercent.toDouble(),
+        saltPercent = saltPercent.toDouble(),
+        yeastType = YeastType.valueOf(yeastType),
+        doughMethod = DoughMethod.valueOf(doughMethod),
+        fermentationSchedule = toFermentationScheduleRequest(),
+        fermentationPreset = fermentationPreset?.let { FermentationPreset.valueOf(it) },
+        roomTemperatureCelsius = roomTemperatureCelsius?.toDouble(),
+        coldTemperatureCelsius = coldTemperatureCelsius?.toDouble(),
+        prefermentFlourPercent = prefermentFlourPercent?.toDouble(),
     )
 }
 
@@ -67,7 +65,7 @@ private fun RecipeRecord.toFermentationScheduleRequest(): FermentationScheduleRe
     )
 }
 
-private fun CreateRecipeRequest.toRecord(
+private fun CreateRecipeRequest.toRecipeRecord(
     recipeId: UUID,
     createdAt: OffsetDateTime,
     isNew: Boolean,
@@ -87,6 +85,8 @@ private fun CreateRecipeRequest.toRecord(
         fermentationScheduleMode = formula.fermentationSchedule?.mode?.name,
         fermentationScheduleRoomHours = formula.fermentationSchedule?.roomHours?.toBigDecimal(),
         fermentationScheduleColdHours = formula.fermentationSchedule?.coldHours?.toBigDecimal(),
+        // The schedule stores its own temperatures because manual schedules can diverge
+        // from the top-level preset-driven temperatures.
         fermentationScheduleRoomTemperatureCelsius = formula.fermentationSchedule?.roomTemperatureCelsius?.toBigDecimal(),
         fermentationScheduleColdTemperatureCelsius = formula.fermentationSchedule?.coldTemperatureCelsius?.toBigDecimal(),
         roomTemperatureCelsius = formula.roomTemperatureCelsius?.toBigDecimal(),

--- a/backend/src/main/kotlin/com/pizzalab/backend/persistence/recipe/RecipeRecordMapper.kt
+++ b/backend/src/main/kotlin/com/pizzalab/backend/persistence/recipe/RecipeRecordMapper.kt
@@ -16,28 +16,19 @@ import java.util.UUID
  * Converts API recipe input into the relational shape stored by Spring Data JDBC.
  */
 fun CreateRecipeRequest.toRecord(): RecipeRecord {
-    val formula = formula
-
-    return RecipeRecord(
+    return toRecord(
         recipeId = UUID.randomUUID(),
-        name = name.trim(),
-        pizzaCount = formula.pizzaCount,
-        doughBallWeightGrams = formula.doughBallWeightGrams.toBigDecimal(),
-        hydrationPercent = formula.hydrationPercent.toBigDecimal(),
-        saltPercent = formula.saltPercent.toBigDecimal(),
-        yeastType = formula.yeastType.name,
-        doughMethod = formula.doughMethod.name,
-        fermentationPreset = formula.fermentationPreset?.name,
-        fermentationScheduleMode = formula.fermentationSchedule?.mode?.name,
-        fermentationScheduleRoomHours = formula.fermentationSchedule?.roomHours?.toBigDecimal(),
-        fermentationScheduleColdHours = formula.fermentationSchedule?.coldHours?.toBigDecimal(),
-        fermentationScheduleRoomTemperatureCelsius = formula.fermentationSchedule?.roomTemperatureCelsius?.toBigDecimal(),
-        fermentationScheduleColdTemperatureCelsius = formula.fermentationSchedule?.coldTemperatureCelsius?.toBigDecimal(),
-        roomTemperatureCelsius = formula.roomTemperatureCelsius?.toBigDecimal(),
-        coldTemperatureCelsius = formula.coldTemperatureCelsius?.toBigDecimal(),
-        prefermentFlourPercent = formula.prefermentFlourPercent?.toBigDecimal(),
         createdAt = OffsetDateTime.now(ZoneOffset.UTC),
-    ).also { it.newRecord = true }
+        isNew = true,
+    )
+}
+
+fun CreateRecipeRequest.toRecord(existingRecord: RecipeRecord): RecipeRecord {
+    return toRecord(
+        recipeId = existingRecord.id,
+        createdAt = existingRecord.createdAt,
+        isNew = false,
+    )
 }
 
 /**
@@ -74,4 +65,33 @@ private fun RecipeRecord.toFermentationScheduleRequest(): FermentationScheduleRe
         roomTemperatureCelsius = fermentationScheduleRoomTemperatureCelsius?.toDouble() ?: 20.0,
         coldTemperatureCelsius = fermentationScheduleColdTemperatureCelsius?.toDouble() ?: 4.0,
     )
+}
+
+private fun CreateRecipeRequest.toRecord(
+    recipeId: UUID,
+    createdAt: OffsetDateTime,
+    isNew: Boolean,
+): RecipeRecord {
+    val formula = formula
+
+    return RecipeRecord(
+        recipeId = recipeId,
+        name = name.trim(),
+        pizzaCount = formula.pizzaCount,
+        doughBallWeightGrams = formula.doughBallWeightGrams.toBigDecimal(),
+        hydrationPercent = formula.hydrationPercent.toBigDecimal(),
+        saltPercent = formula.saltPercent.toBigDecimal(),
+        yeastType = formula.yeastType.name,
+        doughMethod = formula.doughMethod.name,
+        fermentationPreset = formula.fermentationPreset?.name,
+        fermentationScheduleMode = formula.fermentationSchedule?.mode?.name,
+        fermentationScheduleRoomHours = formula.fermentationSchedule?.roomHours?.toBigDecimal(),
+        fermentationScheduleColdHours = formula.fermentationSchedule?.coldHours?.toBigDecimal(),
+        fermentationScheduleRoomTemperatureCelsius = formula.fermentationSchedule?.roomTemperatureCelsius?.toBigDecimal(),
+        fermentationScheduleColdTemperatureCelsius = formula.fermentationSchedule?.coldTemperatureCelsius?.toBigDecimal(),
+        roomTemperatureCelsius = formula.roomTemperatureCelsius?.toBigDecimal(),
+        coldTemperatureCelsius = formula.coldTemperatureCelsius?.toBigDecimal(),
+        prefermentFlourPercent = formula.prefermentFlourPercent?.toBigDecimal(),
+        createdAt = createdAt,
+    ).also { it.newRecord = isNew }
 }

--- a/backend/src/test/kotlin/com/pizzalab/backend/api/recipe/RecipeControllerTest.kt
+++ b/backend/src/test/kotlin/com/pizzalab/backend/api/recipe/RecipeControllerTest.kt
@@ -12,6 +12,8 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -146,6 +148,114 @@ class RecipeControllerTest(
             .andExpect {
                 status { isOk() }
                 jsonPath("$", hasSize<Any>(0))
+            }
+    }
+
+    @Test
+    fun `updates saved recipe`() {
+        val createResult = mockMvc.post("/api/recipes") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                  "name": "Original dough",
+                  "formula": {
+                    "pizzaCount": 4,
+                    "doughBallWeightGrams": 250,
+                    "hydrationPercent": 65,
+                    "saltPercent": 2.8,
+                    "yeastType": "INSTANT",
+                    "doughMethod": "DIRECT",
+                    "fermentationPreset": "ROOM_24H",
+                    "roomTemperatureCelsius": 20
+                  }
+                }
+            """.trimIndent()
+        }
+            .andExpect {
+                status { isOk() }
+            }
+            .andReturn()
+
+        val id = Regex(""""id":"([^"]+)"""")
+            .find(createResult.response.contentAsString)
+            ?.groupValues
+            ?.get(1)
+            ?: error("Recipe id was not returned")
+
+        mockMvc.put("/api/recipes/$id") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                  "name": "Original dough v2",
+                  "formula": {
+                    "pizzaCount": 6,
+                    "doughBallWeightGrams": 270,
+                    "hydrationPercent": 68,
+                    "saltPercent": 2.6,
+                    "yeastType": "FRESH",
+                    "doughMethod": "POOLISH",
+                    "prefermentFlourPercent": 35,
+                    "fermentationSchedule": {
+                      "mode": "MIXED",
+                      "roomHours": 18,
+                      "roomTemperatureCelsius": 21,
+                      "coldHours": 24,
+                      "coldTemperatureCelsius": 4
+                    }
+                  }
+                }
+            """.trimIndent()
+        }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.id") { value(id) }
+                jsonPath("$.name") { value("Original dough v2") }
+                jsonPath("$.formula.pizzaCount") { value(6) }
+                jsonPath("$.formula.doughBallWeightGrams") { value(270.0) }
+                jsonPath("$.formula.hydrationPercent") { value(68.0) }
+                jsonPath("$.formula.saltPercent") { value(2.6) }
+                jsonPath("$.formula.yeastType") { value("FRESH") }
+                jsonPath("$.formula.doughMethod") { value("POOLISH") }
+                jsonPath("$.formula.prefermentFlourPercent") { value(35.0) }
+                jsonPath("$.formula.fermentationSchedule.mode") { value("MIXED") }
+                jsonPath("$.formula.fermentationSchedule.roomHours") { value(18.0) }
+                jsonPath("$.formula.fermentationSchedule.roomTemperatureCelsius") { value(21.0) }
+                jsonPath("$.formula.fermentationSchedule.coldHours") { value(24.0) }
+                jsonPath("$.formula.fermentationSchedule.coldTemperatureCelsius") { value(4.0) }
+            }
+
+        mockMvc.get("/api/recipes")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$", hasSize<Any>(1))
+                jsonPath("$[0].id") { value(id) }
+                jsonPath("$[0].name") { value("Original dough v2") }
+                jsonPath("$[0].formula.doughMethod") { value("POOLISH") }
+            }
+    }
+
+    @Test
+    fun `returns not found when updating missing recipe`() {
+        mockMvc.put("/api/recipes/${UUID.randomUUID()}") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                  "name": "Missing recipe",
+                  "formula": {
+                    "pizzaCount": 4,
+                    "doughBallWeightGrams": 250,
+                    "hydrationPercent": 65,
+                    "saltPercent": 2.8,
+                    "yeastType": "INSTANT",
+                    "doughMethod": "DIRECT",
+                    "fermentationPreset": "ROOM_24H",
+                    "roomTemperatureCelsius": 20
+                  }
+                }
+            """.trimIndent()
+        }
+            .andExpect {
+                status { isNotFound() }
             }
     }
 

--- a/backend/src/test/kotlin/com/pizzalab/backend/api/recipe/RecipeControllerTest.kt
+++ b/backend/src/test/kotlin/com/pizzalab/backend/api/recipe/RecipeControllerTest.kt
@@ -28,24 +28,7 @@ class RecipeControllerTest(
 
     @Test
     fun `creates and lists saved recipes`() {
-        mockMvc.post("/api/recipes") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "24h direct dough",
-                  "formula": {
-                    "pizzaCount": 4,
-                    "doughBallWeightGrams": 250,
-                    "hydrationPercent": 65,
-                    "saltPercent": 2.8,
-                    "yeastType": "INSTANT",
-                    "doughMethod": "DIRECT",
-                    "fermentationPreset": "ROOM_24H",
-                    "roomTemperatureCelsius": 20
-                  }
-                }
-            """.trimIndent()
-        }
+        mockMvc.createRecipe(directRecipePayload(name = "24h direct dough"))
             .andExpect {
                 status { isOk() }
                 jsonPath("$.id") { exists() }
@@ -72,30 +55,7 @@ class RecipeControllerTest(
 
     @Test
     fun `saves manual fermentation schedule fields`() {
-        mockMvc.post("/api/recipes") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "Poolish mixed schedule",
-                  "formula": {
-                    "pizzaCount": 4,
-                    "doughBallWeightGrams": 250,
-                    "hydrationPercent": 65,
-                    "saltPercent": 2.8,
-                    "yeastType": "INSTANT",
-                    "doughMethod": "POOLISH",
-                    "prefermentFlourPercent": 30,
-                    "fermentationSchedule": {
-                      "mode": "MIXED",
-                      "roomHours": 16,
-                      "roomTemperatureCelsius": 20,
-                      "coldHours": 24,
-                      "coldTemperatureCelsius": 4
-                    }
-                  }
-                }
-            """.trimIndent()
-        }
+        mockMvc.createRecipe(poolishSchedulePayload())
             .andExpect {
                 status { isOk() }
                 jsonPath("$.formula.doughMethod") { value("POOLISH") }
@@ -110,34 +70,24 @@ class RecipeControllerTest(
 
     @Test
     fun `deletes saved recipe`() {
-        val createResult = mockMvc.post("/api/recipes") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "Delete me",
-                  "formula": {
-                    "pizzaCount": 2,
-                    "doughBallWeightGrams": 260,
-                    "hydrationPercent": 62,
-                    "saltPercent": 3,
-                    "yeastType": "FRESH",
-                    "doughMethod": "DIRECT",
-                    "fermentationPreset": "COLD_24H",
-                    "coldTemperatureCelsius": 5
-                  }
-                }
-            """.trimIndent()
-        }
+        val createResult = mockMvc.createRecipe(
+            directRecipePayload(
+                name = "Delete me",
+                pizzaCount = 2,
+                doughBallWeightGrams = 260,
+                hydrationPercent = 62,
+                saltPercent = 3,
+                yeastType = "FRESH",
+                fermentationPreset = "COLD_24H",
+                temperatureField = "\"coldTemperatureCelsius\": 5",
+            ),
+        )
             .andExpect {
                 status { isOk() }
             }
             .andReturn()
 
-        val id = Regex(""""id":"([^"]+)"""")
-            .find(createResult.response.contentAsString)
-            ?.groupValues
-            ?.get(1)
-            ?: error("Recipe id was not returned")
+        val id = createResult.recipeId()
 
         mockMvc.delete("/api/recipes/$id")
             .andExpect {
@@ -153,59 +103,15 @@ class RecipeControllerTest(
 
     @Test
     fun `updates saved recipe`() {
-        val createResult = mockMvc.post("/api/recipes") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "Original dough",
-                  "formula": {
-                    "pizzaCount": 4,
-                    "doughBallWeightGrams": 250,
-                    "hydrationPercent": 65,
-                    "saltPercent": 2.8,
-                    "yeastType": "INSTANT",
-                    "doughMethod": "DIRECT",
-                    "fermentationPreset": "ROOM_24H",
-                    "roomTemperatureCelsius": 20
-                  }
-                }
-            """.trimIndent()
-        }
+        val createResult = mockMvc.createRecipe(directRecipePayload(name = "Original dough"))
             .andExpect {
                 status { isOk() }
             }
             .andReturn()
 
-        val id = Regex(""""id":"([^"]+)"""")
-            .find(createResult.response.contentAsString)
-            ?.groupValues
-            ?.get(1)
-            ?: error("Recipe id was not returned")
+        val id = createResult.recipeId()
 
-        mockMvc.put("/api/recipes/$id") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "Original dough v2",
-                  "formula": {
-                    "pizzaCount": 6,
-                    "doughBallWeightGrams": 270,
-                    "hydrationPercent": 68,
-                    "saltPercent": 2.6,
-                    "yeastType": "FRESH",
-                    "doughMethod": "POOLISH",
-                    "prefermentFlourPercent": 35,
-                    "fermentationSchedule": {
-                      "mode": "MIXED",
-                      "roomHours": 18,
-                      "roomTemperatureCelsius": 21,
-                      "coldHours": 24,
-                      "coldTemperatureCelsius": 4
-                    }
-                  }
-                }
-            """.trimIndent()
-        }
+        mockMvc.updateRecipe(id, updatedPoolishPayload())
             .andExpect {
                 status { isOk() }
                 jsonPath("$.id") { value(id) }
@@ -236,24 +142,7 @@ class RecipeControllerTest(
 
     @Test
     fun `returns not found when updating missing recipe`() {
-        mockMvc.put("/api/recipes/${UUID.randomUUID()}") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "Missing recipe",
-                  "formula": {
-                    "pizzaCount": 4,
-                    "doughBallWeightGrams": 250,
-                    "hydrationPercent": 65,
-                    "saltPercent": 2.8,
-                    "yeastType": "INSTANT",
-                    "doughMethod": "DIRECT",
-                    "fermentationPreset": "ROOM_24H",
-                    "roomTemperatureCelsius": 20
-                  }
-                }
-            """.trimIndent()
-        }
+        mockMvc.updateRecipe(UUID.randomUUID().toString(), directRecipePayload(name = "Missing recipe"))
             .andExpect {
                 status { isNotFound() }
             }
@@ -261,21 +150,7 @@ class RecipeControllerTest(
 
     @Test
     fun `returns validation error for invalid recipe payload`() {
-        mockMvc.post("/api/recipes") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "",
-                  "formula": {
-                    "pizzaCount": 0,
-                    "doughBallWeightGrams": 250,
-                    "hydrationPercent": 65,
-                    "saltPercent": 2.8,
-                    "yeastType": "INSTANT"
-                  }
-                }
-            """.trimIndent()
-        }
+        mockMvc.createRecipe(invalidRecipePayload())
             .andExpect {
                 status { isBadRequest() }
                 jsonPath("$.message") { exists() }
@@ -286,24 +161,7 @@ class RecipeControllerTest(
     fun `returns validation error when recipe name exceeds database limit`() {
         val recipeName = "a".repeat(121)
 
-        mockMvc.post("/api/recipes") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "$recipeName",
-                  "formula": {
-                    "pizzaCount": 4,
-                    "doughBallWeightGrams": 250,
-                    "hydrationPercent": 65,
-                    "saltPercent": 2.8,
-                    "yeastType": "INSTANT",
-                    "doughMethod": "DIRECT",
-                    "fermentationPreset": "ROOM_24H",
-                    "roomTemperatureCelsius": 20
-                  }
-                }
-            """.trimIndent()
-        }
+        mockMvc.createRecipe(directRecipePayload(name = recipeName))
             .andExpect {
                 status { isBadRequest() }
                 jsonPath("$.message") { exists() }
@@ -312,22 +170,7 @@ class RecipeControllerTest(
 
     @Test
     fun `returns validation error when recipe formula has no fermentation source`() {
-        mockMvc.post("/api/recipes") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "Missing fermentation",
-                  "formula": {
-                    "pizzaCount": 4,
-                    "doughBallWeightGrams": 250,
-                    "hydrationPercent": 65,
-                    "saltPercent": 2.8,
-                    "yeastType": "INSTANT",
-                    "doughMethod": "DIRECT"
-                  }
-                }
-            """.trimIndent()
-        }
+        mockMvc.createRecipe(missingFermentationPayload())
             .andExpect {
                 status { isBadRequest() }
                 jsonPath("$.message") {
@@ -344,24 +187,7 @@ class RecipeControllerTest(
 
     @Test
     fun `persists large numeric formula values accepted by api validation`() {
-        mockMvc.post("/api/recipes") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "name": "Large formula values",
-                  "formula": {
-                    "pizzaCount": 100000,
-                    "doughBallWeightGrams": 1000000000,
-                    "hydrationPercent": 12345.67,
-                    "saltPercent": 123.45,
-                    "yeastType": "INSTANT",
-                    "doughMethod": "DIRECT",
-                    "fermentationPreset": "ROOM_24H",
-                    "roomTemperatureCelsius": 123.45
-                  }
-                }
-            """.trimIndent()
-        }
+        mockMvc.createRecipe(largeFormulaPayload())
             .andExpect {
                 status { isOk() }
                 jsonPath("$.formula.pizzaCount") { value(100000) }
@@ -372,3 +198,133 @@ class RecipeControllerTest(
             }
     }
 }
+
+private fun MockMvc.createRecipe(content: String) = post("/api/recipes") {
+    contentType = MediaType.APPLICATION_JSON
+    this.content = content
+}
+
+private fun MockMvc.updateRecipe(id: String, content: String) = put("/api/recipes/$id") {
+    contentType = MediaType.APPLICATION_JSON
+    this.content = content
+}
+
+private fun org.springframework.test.web.servlet.MvcResult.recipeId(): String {
+    return Regex(""""id":"([^"]+)"""")
+        .find(response.contentAsString)
+        ?.groupValues
+        ?.get(1)
+        ?: error("Recipe id was not returned")
+}
+
+private fun directRecipePayload(
+    name: String,
+    pizzaCount: Int = 4,
+    doughBallWeightGrams: Int = 250,
+    hydrationPercent: Int = 65,
+    saltPercent: Number = 2.8,
+    yeastType: String = "INSTANT",
+    fermentationPreset: String = "ROOM_24H",
+    temperatureField: String = "\"roomTemperatureCelsius\": 20",
+): String = """
+    {
+      "name": "$name",
+      "formula": {
+        "pizzaCount": $pizzaCount,
+        "doughBallWeightGrams": $doughBallWeightGrams,
+        "hydrationPercent": $hydrationPercent,
+        "saltPercent": $saltPercent,
+        "yeastType": "$yeastType",
+        "doughMethod": "DIRECT",
+        "fermentationPreset": "$fermentationPreset",
+        $temperatureField
+      }
+    }
+""".trimIndent()
+
+private fun poolishSchedulePayload(): String = """
+    {
+      "name": "Poolish mixed schedule",
+      "formula": {
+        "pizzaCount": 4,
+        "doughBallWeightGrams": 250,
+        "hydrationPercent": 65,
+        "saltPercent": 2.8,
+        "yeastType": "INSTANT",
+        "doughMethod": "POOLISH",
+        "prefermentFlourPercent": 30,
+        "fermentationSchedule": {
+          "mode": "MIXED",
+          "roomHours": 16,
+          "roomTemperatureCelsius": 20,
+          "coldHours": 24,
+          "coldTemperatureCelsius": 4
+        }
+      }
+    }
+""".trimIndent()
+
+private fun updatedPoolishPayload(): String = """
+    {
+      "name": "Original dough v2",
+      "formula": {
+        "pizzaCount": 6,
+        "doughBallWeightGrams": 270,
+        "hydrationPercent": 68,
+        "saltPercent": 2.6,
+        "yeastType": "FRESH",
+        "doughMethod": "POOLISH",
+        "prefermentFlourPercent": 35,
+        "fermentationSchedule": {
+          "mode": "MIXED",
+          "roomHours": 18,
+          "roomTemperatureCelsius": 21,
+          "coldHours": 24,
+          "coldTemperatureCelsius": 4
+        }
+      }
+    }
+""".trimIndent()
+
+private fun invalidRecipePayload(): String = """
+    {
+      "name": "",
+      "formula": {
+        "pizzaCount": 0,
+        "doughBallWeightGrams": 250,
+        "hydrationPercent": 65,
+        "saltPercent": 2.8,
+        "yeastType": "INSTANT"
+      }
+    }
+""".trimIndent()
+
+private fun missingFermentationPayload(): String = """
+    {
+      "name": "Missing fermentation",
+      "formula": {
+        "pizzaCount": 4,
+        "doughBallWeightGrams": 250,
+        "hydrationPercent": 65,
+        "saltPercent": 2.8,
+        "yeastType": "INSTANT",
+        "doughMethod": "DIRECT"
+      }
+    }
+""".trimIndent()
+
+private fun largeFormulaPayload(): String = """
+    {
+      "name": "Large formula values",
+      "formula": {
+        "pizzaCount": 100000,
+        "doughBallWeightGrams": 1000000000,
+        "hydrationPercent": 12345.67,
+        "saltPercent": 123.45,
+        "yeastType": "INSTANT",
+        "doughMethod": "DIRECT",
+        "fermentationPreset": "ROOM_24H",
+        "roomTemperatureCelsius": 123.45
+      }
+    }
+""".trimIndent()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -21,11 +23,63 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
+        "jsdom": "^29.1.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.9",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -219,6 +273,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -265,6 +329,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -898,6 +1115,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1659,6 +1894,69 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1669,6 +1967,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2181,6 +2487,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2203,6 +2520,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2232,6 +2560,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2413,12 +2751,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2438,6 +2804,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2455,6 +2828,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2465,12 +2849,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
       "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2916,6 +3321,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2976,6 +3394,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3001,6 +3426,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3375,6 +3851,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3384,6 +3871,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3501,6 +3995,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3597,6 +4104,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3626,6 +4163,24 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3722,6 +4277,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.2",
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3840,6 +4408,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3899,6 +4474,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3971,6 +4592,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4372,6 +5003,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4414,6 +5093,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -24,6 +26,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
+    "jsdom": "^29.1.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.9",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -298,6 +298,31 @@ h1 {
   border: 1px solid #e0e4d8;
   border-radius: 8px;
   background: #fbfcf8;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    transform 120ms ease;
+}
+
+.recipe-item:hover {
+  border-color: #c8cfbb;
+  box-shadow: 0 12px 28px rgba(36, 41, 34, 0.08);
+  transform: translateY(-1px);
+}
+
+.recipe-item.active {
+  border-color: #8f3528;
+  box-shadow: 0 0 0 1px rgba(143, 53, 40, 0.16);
+}
+
+.recipe-item.disabled {
+  cursor: wait;
+}
+
+.recipe-item:focus-visible {
+  outline: 2px solid #8f3528;
+  outline-offset: 2px;
 }
 
 .recipe-actions,
@@ -386,6 +411,80 @@ h1 {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
+}
+
+.recipe-modal-form {
+  display: grid;
+  gap: 18px;
+  margin-bottom: 16px;
+  padding: 18px;
+  border: 1px solid #e0e4d8;
+  border-radius: 8px;
+  background: #fbfcf8;
+}
+
+.recipe-modal-toolbar {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.recipe-modal-toolbar > button,
+.recipe-modal-action-row button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 6px;
+  background: #8f3528;
+  color: #fff;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.recipe-modal-toolbar > button:nth-child(2),
+.recipe-modal-action-row button:last-child {
+  background: #f2f4ec;
+  color: #8f3528;
+}
+
+.recipe-modal-toolbar > button:last-child {
+  background: #fde8e3;
+  color: #9b2c20;
+}
+
+.recipe-modal-name-field {
+  display: grid;
+  gap: 7px;
+  color: #5f685d;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.recipe-modal-name-field input {
+  min-height: 44px;
+  min-width: 0;
+  padding: 0 10px;
+  border: 1px solid #d9ddcf;
+  border-radius: 6px;
+  background: #fbfcf8;
+  color: #1f2520;
+  font: inherit;
+  font-size: 16px;
+  font-weight: 800;
+  outline: 0;
+}
+
+.recipe-modal-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.recipe-modal-hint {
+  margin: 0 0 16px;
+  color: #5f685d;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .recipe-summary-block {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -293,6 +293,10 @@ h1 {
 }
 
 .recipe-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   min-height: 68px;
   padding: 12px 14px;
   border: 1px solid #e0e4d8;
@@ -323,6 +327,10 @@ h1 {
 .recipe-item:focus-visible {
   outline: 2px solid #8f3528;
   outline-offset: 2px;
+}
+
+.recipe-item-body {
+  min-width: 0;
 }
 
 .recipe-actions,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { RecipeManager } from './components/RecipeManager'
 import { ResultsPanel } from './components/ResultsPanel'
 import { buildCalculationRequest } from './api/doughApi'
 import { useDoughCalculator } from './hooks/useDoughCalculator'
+import { applyRecipeFormulaToForm } from './utils/recipeForm'
 
 function App() {
   const {
@@ -19,30 +20,9 @@ function App() {
     calculate,
   } = useDoughCalculator()
   const currentFormula = buildCalculationRequest(form, selectedPreset)
+
   const loadRecipe = (formula: DoughCalculationRequest) => {
-    setForm((current): FormState => ({
-      ...current,
-      pizzaCount: formula.pizzaCount,
-      doughBallWeightGrams: formula.doughBallWeightGrams,
-      hydrationPercent: formula.hydrationPercent,
-      saltPercent: formula.saltPercent,
-      yeastType: formula.yeastType,
-      doughMethod: formula.doughMethod,
-      fermentationPreset: formula.fermentationSchedule
-        ? null
-        : formula.fermentationPreset ?? current.fermentationPreset,
-      fermentationSchedule: formula.fermentationSchedule ?? null,
-      roomTemperatureCelsius:
-        formula.roomTemperatureCelsius ??
-        formula.fermentationSchedule?.roomTemperatureCelsius ??
-        current.roomTemperatureCelsius,
-      coldTemperatureCelsius:
-        formula.coldTemperatureCelsius ??
-        formula.fermentationSchedule?.coldTemperatureCelsius ??
-        current.coldTemperatureCelsius,
-      prefermentFlourPercent:
-        formula.prefermentFlourPercent ?? current.prefermentFlourPercent,
-    }))
+    setForm((current): FormState => applyRecipeFormulaToForm(current, formula))
   }
 
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,7 +73,16 @@ function App() {
           <ResultsPanel result={result} />
         </section>
 
-        <RecipeManager formula={currentFormula} onLoadRecipe={loadRecipe} />
+        <RecipeManager
+          metadata={metadata}
+          form={form}
+          setForm={setForm}
+          compatiblePresets={compatiblePresets}
+          selectedPreset={selectedPreset}
+          calculationError={error}
+          formula={currentFormula}
+          onLoadRecipe={loadRecipe}
+        />
       </section>
     </main>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,6 @@ function App() {
           setForm={setForm}
           compatiblePresets={compatiblePresets}
           selectedPreset={selectedPreset}
-          calculationError={error}
           formula={currentFormula}
           onLoadRecipe={loadRecipe}
         />

--- a/frontend/src/api/recipeApi.test.ts
+++ b/frontend/src/api/recipeApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createRecipe, deleteRecipe, fetchRecipes } from './recipeApi'
+import { createRecipe, deleteRecipe, fetchRecipes, updateRecipe } from './recipeApi'
 import type { CreateRecipeRequest } from '../types/recipe'
 
 const recipeRequest: CreateRecipeRequest = {
@@ -56,6 +56,30 @@ describe('recipeApi', () => {
     await expect(deleteRecipe('recipe-id')).resolves.toBeUndefined()
     expect(fetch).toHaveBeenCalledWith('/api/recipes/recipe-id', {
       method: 'DELETE',
+    })
+  })
+
+  it('updates a recipe', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'recipe-id',
+        ...recipeRequest,
+        name: '24h direct dough v2',
+        createdAt: '2026-04-23T00:00:00Z',
+      }),
+    } as Response)
+
+    await expect(
+      updateRecipe('recipe-id', { ...recipeRequest, name: '24h direct dough v2' }),
+    ).resolves.toMatchObject({
+      id: 'recipe-id',
+      name: '24h direct dough v2',
+    })
+    expect(fetch).toHaveBeenCalledWith('/api/recipes/recipe-id', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...recipeRequest, name: '24h direct dough v2' }),
     })
   })
 })

--- a/frontend/src/api/recipeApi.ts
+++ b/frontend/src/api/recipeApi.ts
@@ -25,6 +25,21 @@ export async function createRecipe(request: CreateRecipeRequest): Promise<Recipe
   return data
 }
 
+export async function updateRecipe(id: string, request: CreateRecipeRequest): Promise<Recipe> {
+  const response = await fetch(`/api/recipes/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  })
+  const data = await response.json()
+
+  if (!response.ok) {
+    throw new Error(data.message ?? 'Recipe update failed')
+  }
+
+  return data
+}
+
 export async function deleteRecipe(id: string): Promise<void> {
   const response = await fetch(`/api/recipes/${id}`, {
     method: 'DELETE',

--- a/frontend/src/components/DoughForm.tsx
+++ b/frontend/src/components/DoughForm.tsx
@@ -18,6 +18,8 @@ type DoughFormProps = {
   error: string | null
   isLoading: boolean
   onSubmit: () => void
+  submitLabel?: string
+  className?: string
 }
 
 export function DoughForm({
@@ -29,10 +31,12 @@ export function DoughForm({
   error,
   isLoading,
   onSubmit,
+  submitLabel = 'Calculate dough',
+  className = 'control-panel',
 }: DoughFormProps) {
   return (
     <form
-      className="control-panel"
+      className={className}
       onSubmit={(event) => {
         event.preventDefault()
         void onSubmit()
@@ -177,7 +181,7 @@ export function DoughForm({
 
       {error && <p className="error-message">{error}</p>}
       <button className="calculate-button" type="submit" disabled={isLoading}>
-        {isLoading ? 'Calculating...' : 'Calculate dough'}
+        {isLoading ? 'Calculating...' : submitLabel}
       </button>
     </form>
   )

--- a/frontend/src/components/RecipeDetailModal.tsx
+++ b/frontend/src/components/RecipeDetailModal.tsx
@@ -8,7 +8,7 @@ type RecipeModalMode = 'view' | 'edit' | 'duplicate'
 
 type RecipeDetailModalProps = {
   recipe: Recipe
-  result: DoughCalculationResponse
+  result: DoughCalculationResponse | null
   mode: RecipeModalMode
   recipeName: string
   sourceRecipeName: string | null
@@ -19,6 +19,7 @@ type RecipeDetailModalProps = {
   compatiblePresets: PresetMetadata[]
   selectedPreset: PresetMetadata | undefined
   formError: string | null
+  resultError: string | null
   onChangeName: (name: string) => void
   onEdit: () => void
   onDuplicate: () => void
@@ -42,6 +43,7 @@ export function RecipeDetailModal({
   compatiblePresets,
   selectedPreset,
   formError,
+  resultError,
   onChangeName,
   onEdit,
   onDuplicate,
@@ -121,15 +123,21 @@ export function RecipeDetailModal({
           />
         )}
 
+        {mode === 'view' && resultError && <p className="error-message">{resultError}</p>}
+
         <div className="recipe-modal-grid">
           <div className="recipe-summary-block">
             <h3>Ingredients</h3>
-            <div className="recipe-ingredients large">
-              <span>Flour {formatGram(result.flourGrams)}</span>
-              <span>Water {formatGram(result.waterGrams)}</span>
-              <span>Salt {formatGram(result.saltGrams)}</span>
-              <span>Yeast {formatGram(result.yeastGrams)}</span>
-            </div>
+            {result ? (
+              <div className="recipe-ingredients large">
+                <span>Flour {formatGram(result.flourGrams)}</span>
+                <span>Water {formatGram(result.waterGrams)}</span>
+                <span>Salt {formatGram(result.saltGrams)}</span>
+                <span>Yeast {formatGram(result.yeastGrams)}</span>
+              </div>
+            ) : (
+              <p className="empty-recipes">Preview unavailable for this saved formula.</p>
+            )}
           </div>
 
           <div className="recipe-summary-block">

--- a/frontend/src/components/RecipeDetailModal.tsx
+++ b/frontend/src/components/RecipeDetailModal.tsx
@@ -1,13 +1,56 @@
+import type { Dispatch, SetStateAction } from 'react'
+import { DoughForm } from './DoughForm'
 import type { DoughCalculationResponse } from '../types/dough'
+import type { DoughMetadata, FormState, PresetMetadata } from '../types/dough'
 import type { Recipe } from '../types/recipe'
+
+type RecipeModalMode = 'view' | 'edit' | 'duplicate'
 
 type RecipeDetailModalProps = {
   recipe: Recipe
   result: DoughCalculationResponse
+  mode: RecipeModalMode
+  recipeName: string
+  sourceRecipeName: string | null
+  isLoading: boolean
+  metadata: DoughMetadata
+  form: FormState
+  setForm: Dispatch<SetStateAction<FormState>>
+  compatiblePresets: PresetMetadata[]
+  selectedPreset: PresetMetadata | undefined
+  formError: string | null
+  onChangeName: (name: string) => void
+  onEdit: () => void
+  onDuplicate: () => void
+  onPreview: () => void
+  onSave: () => void
+  onDelete: () => void
+  onCancelEdit: () => void
   onClose: () => void
 }
 
-export function RecipeDetailModal({ recipe, result, onClose }: RecipeDetailModalProps) {
+export function RecipeDetailModal({
+  recipe,
+  result,
+  mode,
+  recipeName,
+  sourceRecipeName,
+  isLoading,
+  metadata,
+  form,
+  setForm,
+  compatiblePresets,
+  selectedPreset,
+  formError,
+  onChangeName,
+  onEdit,
+  onDuplicate,
+  onPreview,
+  onSave,
+  onDelete,
+  onCancelEdit,
+  onClose,
+}: RecipeDetailModalProps) {
   return (
     <div className="recipe-modal-backdrop" role="presentation">
       <section
@@ -21,10 +64,62 @@ export function RecipeDetailModal({ recipe, result, onClose }: RecipeDetailModal
             <p className="section-title">Recipe</p>
             <h2 id="recipe-modal-title">{recipe.name}</h2>
           </div>
-          <button type="button" onClick={onClose}>
+          <button type="button" onClick={onClose} disabled={isLoading}>
             Close
           </button>
         </header>
+
+        <div className="recipe-modal-toolbar">
+          {mode === 'view' ? (
+            <>
+              <button type="button" onClick={onEdit} disabled={isLoading}>
+                Edit recipe
+              </button>
+              <button type="button" onClick={onDuplicate} disabled={isLoading}>
+                Duplicate
+              </button>
+              <button type="button" onClick={onDelete} disabled={isLoading}>
+                Delete
+              </button>
+            </>
+          ) : (
+            <>
+              <label className="recipe-modal-name-field">
+                <span>{mode === 'duplicate' ? 'Copy name' : 'Recipe name'}</span>
+                <input
+                  value={recipeName}
+                  onChange={(event) => onChangeName(event.target.value)}
+                  placeholder="24h room direct"
+                />
+              </label>
+              <div className="recipe-modal-action-row">
+                <button type="button" onClick={onSave} disabled={isLoading}>
+                  {mode === 'duplicate' ? 'Save copy' : 'Update recipe'}
+                </button>
+                <button type="button" onClick={onCancelEdit} disabled={isLoading}>
+                  Cancel
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+
+        <p className="recipe-modal-hint">{buildModalHint(mode, recipeName, sourceRecipeName)}</p>
+
+        {mode !== 'view' && (
+          <DoughForm
+            metadata={metadata}
+            form={form}
+            setForm={setForm}
+            compatiblePresets={compatiblePresets}
+            selectedPreset={selectedPreset}
+            error={formError}
+            isLoading={isLoading}
+            onSubmit={onPreview}
+            submitLabel="Preview dough"
+            className="recipe-modal-form"
+          />
+        )}
 
         <div className="recipe-modal-grid">
           <div className="recipe-summary-block">
@@ -52,6 +147,22 @@ export function RecipeDetailModal({ recipe, result, onClose }: RecipeDetailModal
       </section>
     </div>
   )
+}
+
+function buildModalHint(
+  mode: RecipeModalMode,
+  recipeName: string,
+  sourceRecipeName: string | null,
+) {
+  if (mode === 'edit') {
+    return `Recipe "${recipeName}" is editable here. Change hydration, method, temperatures, and the rest of the formula below, preview if needed, then save here.`
+  }
+
+  if (mode === 'duplicate' && sourceRecipeName) {
+    return `Copy draft from "${sourceRecipeName}" is editable here. Tweak the full formula below, preview if needed, then save the copy here.`
+  }
+
+  return 'Click Edit recipe to change the loaded formula, or Duplicate to create a new variant from this recipe.'
 }
 
 function FormulaFact({ label, value }: { label: string; value: string | number }) {

--- a/frontend/src/components/RecipeListItem.tsx
+++ b/frontend/src/components/RecipeListItem.tsx
@@ -31,6 +31,10 @@ export function RecipeListItem({
           return
         }
 
+        if (event.currentTarget !== event.target) {
+          return
+        }
+
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault()
           onSelect(recipe)

--- a/frontend/src/components/RecipeListItem.tsx
+++ b/frontend/src/components/RecipeListItem.tsx
@@ -3,11 +3,20 @@ import type { Recipe } from '../types/recipe'
 type RecipeListItemProps = {
   recipe: Recipe
   isDisabled: boolean
-  onOpen: (recipe: Recipe) => void
+  onLoad: (recipe: Recipe) => void
+  onEdit: (recipe: Recipe) => void
+  onDuplicate: (recipe: Recipe) => void
   onDelete: (recipeId: string) => void
 }
 
-export function RecipeListItem({ recipe, isDisabled, onOpen, onDelete }: RecipeListItemProps) {
+export function RecipeListItem({
+  recipe,
+  isDisabled,
+  onLoad,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: RecipeListItemProps) {
   return (
     <article className="recipe-item">
       <div>
@@ -18,8 +27,14 @@ export function RecipeListItem({ recipe, isDisabled, onOpen, onDelete }: RecipeL
         </p>
       </div>
       <div className="recipe-actions">
-        <button type="button" onClick={() => onOpen(recipe)} disabled={isDisabled}>
-          Open
+        <button type="button" onClick={() => onLoad(recipe)} disabled={isDisabled}>
+          Load
+        </button>
+        <button type="button" onClick={() => onEdit(recipe)} disabled={isDisabled}>
+          Edit
+        </button>
+        <button type="button" onClick={() => onDuplicate(recipe)} disabled={isDisabled}>
+          Duplicate
         </button>
         <button
           type="button"

--- a/frontend/src/components/RecipeListItem.tsx
+++ b/frontend/src/components/RecipeListItem.tsx
@@ -5,6 +5,7 @@ type RecipeListItemProps = {
   isActive: boolean
   isDisabled: boolean
   onSelect: (recipe: Recipe) => void
+  onDelete: (recipeId: string) => void
 }
 
 export function RecipeListItem({
@@ -12,6 +13,7 @@ export function RecipeListItem({
   isActive,
   isDisabled,
   onSelect,
+  onDelete,
 }: RecipeListItemProps) {
   return (
     <article
@@ -35,12 +37,25 @@ export function RecipeListItem({
         }
       }}
     >
-      <div>
+      <div className="recipe-item-body">
         <h3>{recipe.name}</h3>
         <p>
           {recipe.formula.doughMethod.toLowerCase()} · {recipe.formula.hydrationPercent}%
           hydration · {recipe.formula.saltPercent}% salt
         </p>
+      </div>
+      <div className="recipe-actions">
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            onDelete(recipe.id)
+          }}
+          disabled={isDisabled}
+          aria-label={`Delete ${recipe.name}`}
+        >
+          Delete
+        </button>
       </div>
     </article>
   )

--- a/frontend/src/components/RecipeListItem.tsx
+++ b/frontend/src/components/RecipeListItem.tsx
@@ -2,48 +2,45 @@ import type { Recipe } from '../types/recipe'
 
 type RecipeListItemProps = {
   recipe: Recipe
+  isActive: boolean
   isDisabled: boolean
-  onLoad: (recipe: Recipe) => void
-  onEdit: (recipe: Recipe) => void
-  onDuplicate: (recipe: Recipe) => void
-  onDelete: (recipeId: string) => void
+  onSelect: (recipe: Recipe) => void
 }
 
 export function RecipeListItem({
   recipe,
+  isActive,
   isDisabled,
-  onLoad,
-  onEdit,
-  onDuplicate,
-  onDelete,
+  onSelect,
 }: RecipeListItemProps) {
   return (
-    <article className="recipe-item">
+    <article
+      className={`recipe-item${isActive ? ' active' : ''}${isDisabled ? ' disabled' : ''}`}
+      role="button"
+      tabIndex={isDisabled ? -1 : 0}
+      aria-pressed={isActive}
+      onClick={() => {
+        if (!isDisabled) {
+          onSelect(recipe)
+        }
+      }}
+      onKeyDown={(event) => {
+        if (isDisabled) {
+          return
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onSelect(recipe)
+        }
+      }}
+    >
       <div>
         <h3>{recipe.name}</h3>
         <p>
           {recipe.formula.doughMethod.toLowerCase()} · {recipe.formula.hydrationPercent}%
           hydration · {recipe.formula.saltPercent}% salt
         </p>
-      </div>
-      <div className="recipe-actions">
-        <button type="button" onClick={() => onLoad(recipe)} disabled={isDisabled}>
-          Load
-        </button>
-        <button type="button" onClick={() => onEdit(recipe)} disabled={isDisabled}>
-          Edit
-        </button>
-        <button type="button" onClick={() => onDuplicate(recipe)} disabled={isDisabled}>
-          Duplicate
-        </button>
-        <button
-          type="button"
-          onClick={() => onDelete(recipe.id)}
-          disabled={isDisabled}
-          aria-label={`Delete ${recipe.name}`}
-        >
-          Delete
-        </button>
       </div>
     </article>
   )

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { useMemo, useState } from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RecipeManager } from './RecipeManager'
@@ -91,6 +91,7 @@ const calculationResult: DoughCalculationResponse = {
 
 describe('RecipeManager', () => {
   afterEach(() => {
+    cleanup()
     vi.restoreAllMocks()
   })
 
@@ -191,6 +192,41 @@ describe('RecipeManager', () => {
       expect(readCurrentFormula()).toEqual({ ...editedFormula, fermentationSchedule: null })
     })
     expect(calculateDough).toHaveBeenNthCalledWith(3, editedFormula)
+  })
+
+  it('restores the loaded recipe formula when modal edits are canceled', async () => {
+    const initialRecipe: Recipe = {
+      id: 'recipe-1',
+      name: 'Original dough',
+      formula: originalFormula,
+      createdAt: '2026-04-27T00:00:00Z',
+    }
+
+    vi.mocked(fetchRecipes).mockResolvedValue([initialRecipe])
+    vi.mocked(deleteRecipe).mockResolvedValue(undefined)
+    vi.mocked(calculateDough).mockResolvedValue(calculationResult)
+
+    render(<RecipeManagerHarness />)
+
+    await userEvent.click(await screen.findByText('Original dough'))
+    await screen.findByRole('button', { name: 'Edit recipe' })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit recipe' }))
+    const hydrationInput = screen.getByDisplayValue('65')
+    await userEvent.clear(hydrationInput)
+    await userEvent.type(hydrationInput, '68')
+    await userEvent.click(screen.getByRole('button', { name: 'Poolish' }))
+
+    await waitFor(() => {
+      expect(readCurrentFormula()).toEqual({ ...editedFormula, fermentationSchedule: null })
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+    await waitFor(() => {
+      expect(readCurrentFormula()).toEqual({ ...originalFormula, fermentationSchedule: null })
+    })
   })
 })
 

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -252,6 +252,29 @@ describe('RecipeManager', () => {
     expect(deleteRecipe).toHaveBeenCalledWith('recipe-1')
     expect(screen.queryByText('Broken preview')).toBeNull()
   })
+
+  it('does not open a recipe when delete is triggered from the keyboard', async () => {
+    const recipe: Recipe = {
+      id: 'recipe-1',
+      name: 'Keyboard delete',
+      formula: originalFormula,
+      createdAt: '2026-04-27T00:00:00Z',
+    }
+
+    vi.mocked(fetchRecipes).mockResolvedValue([recipe])
+    vi.mocked(deleteRecipe).mockResolvedValue(undefined)
+    vi.mocked(calculateDough).mockResolvedValue(calculationResult)
+
+    render(<RecipeManagerHarness />)
+
+    const deleteButton = await screen.findByRole('button', { name: 'Delete Keyboard delete' })
+    deleteButton.focus()
+    await userEvent.keyboard('{Enter}')
+
+    expect(deleteRecipe).toHaveBeenCalledWith('recipe-1')
+    expect(calculateDough).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
 })
 
 function readCurrentFormula() {

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -228,6 +228,30 @@ describe('RecipeManager', () => {
       expect(readCurrentFormula()).toEqual({ ...originalFormula, fermentationSchedule: null })
     })
   })
+
+  it('keeps delete available when recipe preview calculation fails', async () => {
+    const failingRecipe: Recipe = {
+      id: 'recipe-1',
+      name: 'Broken preview',
+      formula: originalFormula,
+      createdAt: '2026-04-27T00:00:00Z',
+    }
+
+    vi.mocked(fetchRecipes).mockResolvedValue([failingRecipe])
+    vi.mocked(deleteRecipe).mockResolvedValue(undefined)
+    vi.mocked(calculateDough).mockRejectedValue(new Error('Recipe calculation failed'))
+
+    render(<RecipeManagerHarness />)
+
+    await userEvent.click(await screen.findByText('Broken preview'))
+    expect(await screen.findByText('Recipe calculation failed')).toBeTruthy()
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Broken preview' }))
+
+    expect(deleteRecipe).toHaveBeenCalledWith('recipe-1')
+    expect(screen.queryByText('Broken preview')).toBeNull()
+  })
 })
 
 function readCurrentFormula() {

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { useState } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RecipeManager } from './RecipeManager'
+import type { DoughCalculationRequest, DoughCalculationResponse } from '../types/dough'
+import type { Recipe } from '../types/recipe'
+import {
+  createRecipe,
+  deleteRecipe,
+  fetchRecipes,
+  updateRecipe,
+} from '../api/recipeApi'
+import { calculateDough } from '../api/doughApi'
+
+vi.mock('../api/recipeApi', () => ({
+  fetchRecipes: vi.fn(),
+  createRecipe: vi.fn(),
+  updateRecipe: vi.fn(),
+  deleteRecipe: vi.fn(),
+}))
+
+vi.mock('../api/doughApi', () => ({
+  calculateDough: vi.fn(),
+}))
+
+const originalFormula: DoughCalculationRequest = {
+  pizzaCount: 4,
+  doughBallWeightGrams: 250,
+  hydrationPercent: 65,
+  saltPercent: 2.8,
+  yeastType: 'INSTANT',
+  doughMethod: 'DIRECT',
+  fermentationPreset: 'ROOM_24H',
+  roomTemperatureCelsius: 20,
+}
+
+const editedFormula: DoughCalculationRequest = {
+  pizzaCount: 6,
+  doughBallWeightGrams: 270,
+  hydrationPercent: 68,
+  saltPercent: 2.6,
+  yeastType: 'FRESH',
+  doughMethod: 'POOLISH',
+  fermentationSchedule: {
+    mode: 'MIXED',
+    roomHours: 18,
+    roomTemperatureCelsius: 21,
+    coldHours: 24,
+    coldTemperatureCelsius: 4,
+  },
+  prefermentFlourPercent: 35,
+}
+
+const calculationResult: DoughCalculationResponse = {
+  flourGrams: 1000,
+  waterGrams: 650,
+  saltGrams: 28,
+  yeastGrams: 1.5,
+  totalDoughWeightGrams: 1679.5,
+  preferment: null,
+  finalMix: {
+    flourGrams: 1000,
+    waterGrams: 650,
+    saltGrams: 28,
+    yeastGrams: 1.5,
+  },
+  yeastCalculation: {
+    yeastType: 'INSTANT',
+    doughMethod: 'DIRECT',
+    roomEffectHours: 24,
+    coldEffectHours: 0,
+    effectiveFermentationHours: 24,
+    freshYeastPercent: 0.12,
+    selectedYeastPercent: 0.04,
+    freshYeastEquivalentGrams: 1.2,
+    selectedYeastGrams: 0.4,
+    prefermentYeastGrams: 0,
+    finalMixYeastGrams: 0.4,
+  },
+}
+
+describe('RecipeManager', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('supports load, edit, and duplicate flows without breaking calculation', async () => {
+    const initialRecipe: Recipe = {
+      id: 'recipe-1',
+      name: 'Original dough',
+      formula: originalFormula,
+      createdAt: '2026-04-27T00:00:00Z',
+    }
+    const updatedRecipe: Recipe = {
+      ...initialRecipe,
+      name: 'Original dough v2',
+      formula: editedFormula,
+    }
+    const duplicatedRecipe: Recipe = {
+      id: 'recipe-2',
+      name: 'Original dough v2 copy',
+      formula: editedFormula,
+      createdAt: '2026-04-27T00:05:00Z',
+    }
+
+    vi.mocked(fetchRecipes).mockResolvedValue([initialRecipe])
+    vi.mocked(updateRecipe).mockResolvedValue(updatedRecipe)
+    vi.mocked(createRecipe).mockResolvedValue(duplicatedRecipe)
+    vi.mocked(deleteRecipe).mockResolvedValue(undefined)
+    vi.mocked(calculateDough).mockResolvedValue(calculationResult)
+
+    render(<RecipeManagerHarness />)
+
+    expect(await screen.findByText('Original dough')).toBeTruthy()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Load' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-formula').textContent).toBe(JSON.stringify(originalFormula))
+    })
+    expect(calculateDough).toHaveBeenCalledWith(originalFormula)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Apply variant formula' }))
+    await userEvent.clear(screen.getByPlaceholderText('24h room direct'))
+    await userEvent.type(screen.getByPlaceholderText('24h room direct'), 'Original dough v2')
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    expect(updateRecipe).toHaveBeenCalledWith('recipe-1', {
+      name: 'Original dough v2',
+      formula: editedFormula,
+    })
+    expect((await screen.findAllByText('Original dough v2')).length).toBeGreaterThan(0)
+    await waitFor(() => {
+      expect(screen.getByTestId('current-formula').textContent).toBe(JSON.stringify(editedFormula))
+    })
+
+    const duplicateButtons = screen.getAllByRole('button', { name: 'Duplicate' })
+    await userEvent.click(duplicateButtons[0])
+
+    expect(createRecipe).toHaveBeenCalledWith({
+      name: 'Original dough v2 copy',
+      formula: editedFormula,
+    })
+    expect((await screen.findAllByText('Original dough v2 copy')).length).toBeGreaterThan(0)
+    await waitFor(() => {
+      expect(screen.getByTestId('current-formula').textContent).toBe(JSON.stringify(editedFormula))
+    })
+    expect(calculateDough).toHaveBeenNthCalledWith(1, originalFormula)
+    expect(calculateDough).toHaveBeenNthCalledWith(2, editedFormula)
+    expect(calculateDough).toHaveBeenNthCalledWith(3, editedFormula)
+  })
+})
+
+function RecipeManagerHarness() {
+  const [formula, setFormula] = useState<DoughCalculationRequest>({
+    pizzaCount: 2,
+    doughBallWeightGrams: 230,
+    hydrationPercent: 62,
+    saltPercent: 2.9,
+    yeastType: 'ACTIVE_DRY',
+    doughMethod: 'DIRECT',
+    fermentationPreset: 'COLD_24H',
+    coldTemperatureCelsius: 4,
+  })
+
+  return (
+    <>
+      <button type="button" onClick={() => setFormula(editedFormula)}>
+        Apply variant formula
+      </button>
+      <output data-testid="current-formula">{JSON.stringify(formula)}</output>
+      <RecipeManager formula={formula} onLoadRecipe={setFormula} />
+    </>
+  )
+}

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -298,6 +298,8 @@ describe('RecipeManager', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Preview dough' }))
 
     expect(await screen.findByText('Preview failed')).toBeTruthy()
+    expect(screen.getByText('Preview unavailable for this saved formula.')).toBeTruthy()
+    expect(screen.queryByText('Flour 1000.0g')).toBeNull()
     expect(screen.getByRole('dialog')).toBeTruthy()
   })
 

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -360,6 +360,27 @@ describe('RecipeManager', () => {
     expect(screen.queryByText('Flour 1000.0g')).toBeNull()
     expect(screen.getByRole('dialog')).toBeTruthy()
   })
+
+  it('shows delete failures inside the modal', async () => {
+    const recipe: Recipe = {
+      id: 'recipe-1',
+      name: 'Delete failure',
+      formula: originalFormula,
+      createdAt: '2026-04-27T00:00:00Z',
+    }
+
+    vi.mocked(fetchRecipes).mockResolvedValue([recipe])
+    vi.mocked(deleteRecipe).mockRejectedValue(new Error('Delete failed'))
+    vi.mocked(calculateDough).mockResolvedValue(calculationResult)
+
+    render(<RecipeManagerHarness />)
+
+    await userEvent.click(await screen.findByText('Delete failure'))
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+    expect(await screen.findByText('Delete failed')).toBeTruthy()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
 })
 
 function readCurrentFormula() {

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -13,6 +13,7 @@ import type {
   FormState,
 } from '../types/dough'
 import type { Recipe } from '../types/recipe'
+import { applyRecipeFormulaToForm } from '../utils/recipeForm'
 import {
   createRecipe,
   deleteRecipe,
@@ -237,29 +238,7 @@ function RecipeManagerHarness() {
         calculationError={null}
         formula={formula}
         onLoadRecipe={(loadedFormula) =>
-          setForm((current) => ({
-            ...current,
-            pizzaCount: loadedFormula.pizzaCount,
-            doughBallWeightGrams: loadedFormula.doughBallWeightGrams,
-            hydrationPercent: loadedFormula.hydrationPercent,
-            saltPercent: loadedFormula.saltPercent,
-            yeastType: loadedFormula.yeastType,
-            doughMethod: loadedFormula.doughMethod,
-            fermentationPreset: loadedFormula.fermentationSchedule
-              ? null
-              : loadedFormula.fermentationPreset ?? current.fermentationPreset,
-            fermentationSchedule: loadedFormula.fermentationSchedule ?? null,
-            roomTemperatureCelsius:
-              loadedFormula.roomTemperatureCelsius ??
-              loadedFormula.fermentationSchedule?.roomTemperatureCelsius ??
-              current.roomTemperatureCelsius,
-            coldTemperatureCelsius:
-              loadedFormula.coldTemperatureCelsius ??
-              loadedFormula.fermentationSchedule?.coldTemperatureCelsius ??
-              current.coldTemperatureCelsius,
-            prefermentFlourPercent:
-              loadedFormula.prefermentFlourPercent ?? current.prefermentFlourPercent,
-          }))
+          setForm((current) => applyRecipeFormulaToForm(current, loadedFormula))
         }
       />
     </>

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RecipeManager } from './RecipeManager'
-import type { DoughCalculationRequest, DoughCalculationResponse } from '../types/dough'
+import { buildCalculationRequest } from '../api/doughApi'
+import { defaultMetadata } from '../data/doughDefaults'
+import type {
+  DoughCalculationRequest,
+  DoughCalculationResponse,
+  FormState,
+} from '../types/dough'
 import type { Recipe } from '../types/recipe'
 import {
   createRecipe,
@@ -22,9 +28,14 @@ vi.mock('../api/recipeApi', () => ({
   deleteRecipe: vi.fn(),
 }))
 
-vi.mock('../api/doughApi', () => ({
-  calculateDough: vi.fn(),
-}))
+vi.mock('../api/doughApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/doughApi')>()
+
+  return {
+    ...actual,
+    calculateDough: vi.fn(),
+  }
+})
 
 const originalFormula: DoughCalculationRequest = {
   pizzaCount: 4,
@@ -38,20 +49,15 @@ const originalFormula: DoughCalculationRequest = {
 }
 
 const editedFormula: DoughCalculationRequest = {
-  pizzaCount: 6,
-  doughBallWeightGrams: 270,
+  pizzaCount: 4,
+  doughBallWeightGrams: 250,
   hydrationPercent: 68,
-  saltPercent: 2.6,
-  yeastType: 'FRESH',
+  saltPercent: 2.8,
+  yeastType: 'INSTANT',
   doughMethod: 'POOLISH',
-  fermentationSchedule: {
-    mode: 'MIXED',
-    roomHours: 18,
-    roomTemperatureCelsius: 21,
-    coldHours: 24,
-    coldTemperatureCelsius: 4,
-  },
-  prefermentFlourPercent: 35,
+  fermentationPreset: 'ROOM_24H',
+  roomTemperatureCelsius: 20,
+  prefermentFlourPercent: 30,
 }
 
 const calculationResult: DoughCalculationResponse = {
@@ -87,7 +93,7 @@ describe('RecipeManager', () => {
     vi.restoreAllMocks()
   })
 
-  it('supports load, edit, and duplicate flows without breaking calculation', async () => {
+  it('opens recipes on click and edits or duplicates them from the modal', async () => {
     const initialRecipe: Recipe = {
       id: 'recipe-1',
       name: 'Original dough',
@@ -115,48 +121,84 @@ describe('RecipeManager', () => {
     render(<RecipeManagerHarness />)
 
     expect(await screen.findByText('Original dough')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Load' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull()
 
-    await userEvent.click(screen.getByRole('button', { name: 'Load' }))
+    await userEvent.click(screen.getByText('Original dough'))
 
     await waitFor(() => {
-      expect(screen.getByTestId('current-formula').textContent).toBe(JSON.stringify(originalFormula))
+      expect(readCurrentFormula()).toEqual({ ...originalFormula, fermentationSchedule: null })
     })
-    expect(calculateDough).toHaveBeenCalledWith(originalFormula)
+    expect(await screen.findByRole('button', { name: 'Edit recipe' })).toBeTruthy()
+    expect(screen.getByText(/Click Edit recipe to change the loaded formula/)).toBeTruthy()
+    expect(calculateDough).toHaveBeenNthCalledWith(1, originalFormula)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    await userEvent.click(screen.getByRole('button', { name: 'Apply variant formula' }))
-    await userEvent.clear(screen.getByPlaceholderText('24h room direct'))
-    await userEvent.type(screen.getByPlaceholderText('24h room direct'), 'Original dough v2')
-    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Edit recipe' }))
+    await userEvent.clear(screen.getByDisplayValue('Original dough'))
+    await userEvent.type(screen.getByRole('textbox', { name: 'Recipe name' }), 'Original dough v2')
+    expect(screen.getByRole('button', { name: 'Preview dough' })).toBeTruthy()
+    expect(screen.getByText(/Change hydration, method, temperatures, and the rest of the formula below/)).toBeTruthy()
+    const hydrationInput = screen.getByDisplayValue('65')
+    await userEvent.clear(hydrationInput)
+    await userEvent.type(hydrationInput, '68')
+    await userEvent.click(screen.getByRole('button', { name: 'Poolish' }))
+    await waitFor(() => {
+      expect(readCurrentFormula()).toEqual({ ...editedFormula, fermentationSchedule: null })
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'Update recipe' }))
 
     expect(updateRecipe).toHaveBeenCalledWith('recipe-1', {
       name: 'Original dough v2',
-      formula: editedFormula,
+      formula: expect.objectContaining({
+        hydrationPercent: 68,
+        doughMethod: 'POOLISH',
+        fermentationPreset: 'ROOM_24H',
+        prefermentFlourPercent: 30,
+      }),
     })
     expect((await screen.findAllByText('Original dough v2')).length).toBeGreaterThan(0)
     await waitFor(() => {
-      expect(screen.getByTestId('current-formula').textContent).toBe(JSON.stringify(editedFormula))
+      expect(readCurrentFormula()).toEqual({ ...editedFormula, fermentationSchedule: null })
+    })
+    expect(calculateDough).toHaveBeenNthCalledWith(2, editedFormula)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Duplicate' }))
+
+    expect(createRecipe).not.toHaveBeenCalled()
+    expect(screen.getByDisplayValue('Original dough v2 copy')).toBeTruthy()
+    expect(
+      screen.getByText(/Copy draft from "Original dough v2" is editable here/),
+    ).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Save copy' })).toBeTruthy()
+    await waitFor(() => {
+      expect(readCurrentFormula()).toEqual({ ...editedFormula, fermentationSchedule: null })
     })
 
-    const duplicateButtons = screen.getAllByRole('button', { name: 'Duplicate' })
-    await userEvent.click(duplicateButtons[0])
+    await userEvent.click(screen.getByRole('button', { name: 'Save copy' }))
 
     expect(createRecipe).toHaveBeenCalledWith({
       name: 'Original dough v2 copy',
-      formula: editedFormula,
+      formula: expect.objectContaining({
+        hydrationPercent: 68,
+        doughMethod: 'POOLISH',
+        fermentationPreset: 'ROOM_24H',
+        prefermentFlourPercent: 30,
+      }),
     })
     expect((await screen.findAllByText('Original dough v2 copy')).length).toBeGreaterThan(0)
     await waitFor(() => {
-      expect(screen.getByTestId('current-formula').textContent).toBe(JSON.stringify(editedFormula))
+      expect(readCurrentFormula()).toEqual({ ...editedFormula, fermentationSchedule: null })
     })
-    expect(calculateDough).toHaveBeenNthCalledWith(1, originalFormula)
-    expect(calculateDough).toHaveBeenNthCalledWith(2, editedFormula)
     expect(calculateDough).toHaveBeenNthCalledWith(3, editedFormula)
   })
 })
 
+function readCurrentFormula() {
+  return JSON.parse(screen.getByTestId('current-formula').textContent ?? 'null')
+}
+
 function RecipeManagerHarness() {
-  const [formula, setFormula] = useState<DoughCalculationRequest>({
+  const [form, setForm] = useState<FormState>({
     pizzaCount: 2,
     doughBallWeightGrams: 230,
     hydrationPercent: 62,
@@ -164,16 +206,62 @@ function RecipeManagerHarness() {
     yeastType: 'ACTIVE_DRY',
     doughMethod: 'DIRECT',
     fermentationPreset: 'COLD_24H',
+    fermentationSchedule: null,
+    roomTemperatureCelsius: 20,
     coldTemperatureCelsius: 4,
+    prefermentFlourPercent: 30,
   })
+  const compatiblePresets = useMemo(
+    () =>
+      defaultMetadata.fermentationPresets.filter((preset) =>
+        preset.compatibleDoughMethods.includes(form.doughMethod),
+      ),
+    [form.doughMethod],
+  )
+  const selectedPreset =
+    form.fermentationSchedule
+      ? undefined
+      : compatiblePresets.find((preset) => preset.code === form.fermentationPreset) ??
+        compatiblePresets[0]
+  const formula = buildCalculationRequest(form, selectedPreset)
 
   return (
     <>
-      <button type="button" onClick={() => setFormula(editedFormula)}>
-        Apply variant formula
-      </button>
       <output data-testid="current-formula">{JSON.stringify(formula)}</output>
-      <RecipeManager formula={formula} onLoadRecipe={setFormula} />
+      <RecipeManager
+        metadata={defaultMetadata}
+        form={form}
+        setForm={setForm}
+        compatiblePresets={compatiblePresets}
+        selectedPreset={selectedPreset}
+        calculationError={null}
+        formula={formula}
+        onLoadRecipe={(loadedFormula) =>
+          setForm((current) => ({
+            ...current,
+            pizzaCount: loadedFormula.pizzaCount,
+            doughBallWeightGrams: loadedFormula.doughBallWeightGrams,
+            hydrationPercent: loadedFormula.hydrationPercent,
+            saltPercent: loadedFormula.saltPercent,
+            yeastType: loadedFormula.yeastType,
+            doughMethod: loadedFormula.doughMethod,
+            fermentationPreset: loadedFormula.fermentationSchedule
+              ? null
+              : loadedFormula.fermentationPreset ?? current.fermentationPreset,
+            fermentationSchedule: loadedFormula.fermentationSchedule ?? null,
+            roomTemperatureCelsius:
+              loadedFormula.roomTemperatureCelsius ??
+              loadedFormula.fermentationSchedule?.roomTemperatureCelsius ??
+              current.roomTemperatureCelsius,
+            coldTemperatureCelsius:
+              loadedFormula.coldTemperatureCelsius ??
+              loadedFormula.fermentationSchedule?.coldTemperatureCelsius ??
+              current.coldTemperatureCelsius,
+            prefermentFlourPercent:
+              loadedFormula.prefermentFlourPercent ?? current.prefermentFlourPercent,
+          }))
+        }
+      />
     </>
   )
 }

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -247,6 +247,7 @@ describe('RecipeManager', () => {
     expect(await screen.findByText('Recipe calculation failed')).toBeTruthy()
     expect(screen.getByRole('dialog')).toBeTruthy()
     expect(screen.getByText('Preview unavailable for this saved formula.')).toBeTruthy()
+    expect(screen.queryAllByText('Recipe calculation failed').length).toBeGreaterThan(0)
 
     await userEvent.click(screen.getByRole('button', { name: 'Delete Broken preview' }))
 

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -275,6 +275,53 @@ describe('RecipeManager', () => {
     expect(calculateDough).not.toHaveBeenCalled()
     expect(screen.queryByRole('dialog')).toBeNull()
   })
+
+  it('shows preview failures inside the modal form', async () => {
+    const recipe: Recipe = {
+      id: 'recipe-1',
+      name: 'Preview failure',
+      formula: originalFormula,
+      createdAt: '2026-04-27T00:00:00Z',
+    }
+
+    vi.mocked(fetchRecipes).mockResolvedValue([recipe])
+    vi.mocked(deleteRecipe).mockResolvedValue(undefined)
+    vi.mocked(calculateDough)
+      .mockResolvedValueOnce(calculationResult)
+      .mockRejectedValueOnce(new Error('Preview failed'))
+
+    render(<RecipeManagerHarness />)
+
+    await userEvent.click(await screen.findByText('Preview failure'))
+    await userEvent.click(await screen.findByRole('button', { name: 'Edit recipe' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Preview dough' }))
+
+    expect(await screen.findByText('Preview failed')).toBeTruthy()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
+
+  it('shows save failures inside the modal form', async () => {
+    const recipe: Recipe = {
+      id: 'recipe-1',
+      name: 'Save failure',
+      formula: originalFormula,
+      createdAt: '2026-04-27T00:00:00Z',
+    }
+
+    vi.mocked(fetchRecipes).mockResolvedValue([recipe])
+    vi.mocked(deleteRecipe).mockResolvedValue(undefined)
+    vi.mocked(calculateDough).mockResolvedValue(calculationResult)
+    vi.mocked(updateRecipe).mockRejectedValue(new Error('Update failed'))
+
+    render(<RecipeManagerHarness />)
+
+    await userEvent.click(await screen.findByText('Save failure'))
+    await userEvent.click(await screen.findByRole('button', { name: 'Edit recipe' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Update recipe' }))
+
+    expect(await screen.findByText('Update failed')).toBeTruthy()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
 })
 
 function readCurrentFormula() {

--- a/frontend/src/components/RecipeManager.test.tsx
+++ b/frontend/src/components/RecipeManager.test.tsx
@@ -245,7 +245,8 @@ describe('RecipeManager', () => {
 
     await userEvent.click(await screen.findByText('Broken preview'))
     expect(await screen.findByText('Recipe calculation failed')).toBeTruthy()
-    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByText('Preview unavailable for this saved formula.')).toBeTruthy()
 
     await userEvent.click(screen.getByRole('button', { name: 'Delete Broken preview' }))
 
@@ -322,6 +323,40 @@ describe('RecipeManager', () => {
     expect(await screen.findByText('Update failed')).toBeTruthy()
     expect(screen.getByRole('dialog')).toBeTruthy()
   })
+
+  it('clears stale preview totals when recalculation fails after saving from the modal', async () => {
+    const recipe: Recipe = {
+      id: 'recipe-1',
+      name: 'Recalc failure',
+      formula: originalFormula,
+      createdAt: '2026-04-27T00:00:00Z',
+    }
+    const updatedRecipe: Recipe = {
+      ...recipe,
+      name: 'Recalc failure v2',
+      formula: editedFormula,
+    }
+
+    vi.mocked(fetchRecipes).mockResolvedValue([recipe])
+    vi.mocked(deleteRecipe).mockResolvedValue(undefined)
+    vi.mocked(updateRecipe).mockResolvedValue(updatedRecipe)
+    vi.mocked(calculateDough)
+      .mockResolvedValueOnce(calculationResult)
+      .mockRejectedValueOnce(new Error('Recalculation failed'))
+
+    render(<RecipeManagerHarness />)
+
+    await userEvent.click(await screen.findByText('Recalc failure'))
+    await userEvent.click(await screen.findByRole('button', { name: 'Edit recipe' }))
+    await userEvent.clear(screen.getByDisplayValue('Recalc failure'))
+    await userEvent.type(screen.getByRole('textbox', { name: 'Recipe name' }), 'Recalc failure v2')
+    await userEvent.click(screen.getByRole('button', { name: 'Update recipe' }))
+
+    expect(await screen.findByText('Recalculation failed')).toBeTruthy()
+    expect(screen.getByText('Preview unavailable for this saved formula.')).toBeTruthy()
+    expect(screen.queryByText('Flour 1000.0g')).toBeNull()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
 })
 
 function readCurrentFormula() {
@@ -365,7 +400,6 @@ function RecipeManagerHarness() {
         setForm={setForm}
         compatiblePresets={compatiblePresets}
         selectedPreset={selectedPreset}
-        calculationError={null}
         formula={formula}
         onLoadRecipe={(loadedFormula) =>
           setForm((current) => applyRecipeFormulaToForm(current, loadedFormula))

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -42,6 +42,7 @@ export function RecipeManager({
   onLoadRecipe,
 }: RecipeManagerProps) {
   const [recipes, setRecipes] = useState<Recipe[]>([])
+  const [loadedRecipe, setLoadedRecipe] = useState<Recipe | null>(null)
   const [preview, setPreview] = useState<RecipePreview | null>(null)
   const [newRecipeName, setNewRecipeName] = useState('')
   const [activeRecipeId, setActiveRecipeId] = useState<string | null>(null)
@@ -116,6 +117,7 @@ export function RecipeManager({
       setPreview((currentPreview) => (currentPreview?.recipe.id === id ? null : currentPreview))
       if (activeRecipeId === id) {
         setActiveRecipeId(null)
+        setLoadedRecipe(null)
       }
       if (preview?.recipe.id === id) {
         resetModal()
@@ -143,6 +145,7 @@ export function RecipeManager({
 
   const openRecipe = async (recipe: Recipe) => {
     setError(null)
+    setLoadedRecipe(recipe)
     setActiveRecipeId(recipe.id)
     setModalMode('view')
     setSourceRecipeName(null)
@@ -152,31 +155,30 @@ export function RecipeManager({
   }
 
   const startEditingRecipe = () => {
-    if (!preview) {
+    if (!loadedRecipe) {
       return
     }
 
     setError(null)
     setModalMode('edit')
-    setModalRecipeName(preview.recipe.name)
+    setModalRecipeName(loadedRecipe.name)
     setSourceRecipeName(null)
-    setActiveRecipeId(preview.recipe.id)
-    onLoadRecipe(preview.recipe.formula)
+    setActiveRecipeId(loadedRecipe.id)
+    onLoadRecipe(loadedRecipe.formula)
   }
 
   const startDuplicateRecipe = () => {
-    if (!preview) {
+    if (!loadedRecipe) {
       return
     }
 
-    const recipe = preview.recipe
-    const duplicateName = buildDuplicateRecipeName(recipe.name, recipes)
+    const duplicateName = buildDuplicateRecipeName(loadedRecipe.name, recipes)
 
     setError(null)
     setModalMode('duplicate')
-    setSourceRecipeName(recipe.name)
+    setSourceRecipeName(loadedRecipe.name)
     setModalRecipeName(duplicateName)
-    onLoadRecipe(recipe.formula)
+    onLoadRecipe(loadedRecipe.formula)
   }
 
   const saveModalRecipe = async () => {
@@ -310,6 +312,10 @@ export function RecipeManager({
   )
 
   function resetModal() {
+    if (modalMode !== 'view' && loadedRecipe) {
+      onLoadRecipe(loadedRecipe.formula)
+    }
+
     setPreview(null)
     setModalMode('view')
     setModalRecipeName('')

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -51,20 +51,14 @@ export function RecipeManager({
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // While the modal is in edit or duplicate mode, keep the preview card in sync
+  // with the draft name and formula the user is currently adjusting.
   const modalRecipe = useMemo(() => {
     if (!preview) {
       return null
     }
 
-    if (modalMode === 'view') {
-      return preview.recipe
-    }
-
-    return {
-      ...preview.recipe,
-      name: modalRecipeName.trim() || preview.recipe.name,
-      formula,
-    }
+    return buildModalRecipe(preview.recipe, modalMode, modalRecipeName, formula)
   }, [formula, modalMode, modalRecipeName, preview])
 
   useEffect(() => {
@@ -236,11 +230,7 @@ export function RecipeManager({
     try {
       const result = await calculateDough(formula)
       setPreview({
-        recipe: {
-          ...preview.recipe,
-          name: modalRecipeName.trim() || preview.recipe.name,
-          formula,
-        },
+        recipe: buildModalRecipe(preview.recipe, modalMode, modalRecipeName, formula),
         result,
       })
     } catch (caught) {
@@ -325,6 +315,23 @@ export function RecipeManager({
     setModalRecipeName('')
     setSourceRecipeName(null)
     setError(null)
+  }
+}
+
+function buildModalRecipe(
+  recipe: Recipe,
+  mode: ModalMode,
+  recipeName: string,
+  formula: DoughCalculationRequest,
+) {
+  if (mode === 'view') {
+    return recipe
+  }
+
+  return {
+    ...recipe,
+    name: recipeName.trim() || recipe.name,
+    formula,
   }
 }
 

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { calculateDough } from '../api/doughApi'
-import { createRecipe, deleteRecipe, fetchRecipes } from '../api/recipeApi'
+import { createRecipe, deleteRecipe, fetchRecipes, updateRecipe } from '../api/recipeApi'
 import type { DoughCalculationRequest, DoughCalculationResponse } from '../types/dough'
 import type { Recipe } from '../types/recipe'
 import { RecipeDetailModal } from './RecipeDetailModal'
@@ -20,6 +20,7 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
   const [recipes, setRecipes] = useState<Recipe[]>([])
   const [preview, setPreview] = useState<RecipePreview | null>(null)
   const [recipeName, setRecipeName] = useState('')
+  const [activeRecipeId, setActiveRecipeId] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -57,12 +58,26 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
     setError(null)
 
     try {
-      const savedRecipe = await createRecipe({ name, formula })
-      setRecipes((currentRecipes) => [savedRecipe, ...currentRecipes])
-      await openRecipe(savedRecipe)
-      setRecipeName('')
+      const savedRecipe = activeRecipeId
+        ? await updateRecipe(activeRecipeId, { name, formula })
+        : await createRecipe({ name, formula })
+
+      setRecipes((currentRecipes) =>
+        activeRecipeId
+          ? currentRecipes.map((recipe) => (recipe.id === savedRecipe.id ? savedRecipe : recipe))
+          : [savedRecipe, ...currentRecipes],
+      )
+      setActiveRecipeId(savedRecipe.id)
+      setRecipeName(savedRecipe.name)
+      await loadRecipe(savedRecipe)
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Recipe save failed')
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : activeRecipeId
+            ? 'Recipe update failed'
+            : 'Recipe save failed',
+      )
     } finally {
       setIsLoading(false)
     }
@@ -76,6 +91,10 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
       await deleteRecipe(id)
       setRecipes((currentRecipes) => currentRecipes.filter((recipe) => recipe.id !== id))
       setPreview((currentPreview) => (currentPreview?.recipe.id === id ? null : currentPreview))
+      if (activeRecipeId === id) {
+        setActiveRecipeId(null)
+        setRecipeName('')
+      }
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Recipe delete failed')
     } finally {
@@ -98,8 +117,50 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
   }
 
   const openRecipe = async (recipe: Recipe) => {
+    setActiveRecipeId(recipe.id)
+    setRecipeName(recipe.name)
     onLoadRecipe(recipe.formula)
     await showRecipe(recipe)
+  }
+
+  const loadRecipe = async (recipe: Recipe) => {
+    await openRecipe(recipe)
+  }
+
+  const editRecipe = (recipe: Recipe) => {
+    setError(null)
+    setActiveRecipeId(recipe.id)
+    setRecipeName(recipe.name)
+    onLoadRecipe(recipe.formula)
+  }
+
+  const duplicateRecipe = async (recipe: Recipe) => {
+    const duplicateName = buildDuplicateRecipeName(recipe.name, recipes)
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const duplicatedRecipe = await createRecipe({
+        name: duplicateName,
+        formula: recipe.formula,
+      })
+      setRecipes((currentRecipes) => [duplicatedRecipe, ...currentRecipes])
+      setActiveRecipeId(duplicatedRecipe.id)
+      setRecipeName(duplicatedRecipe.name)
+      onLoadRecipe(duplicatedRecipe.formula)
+      await showRecipe(duplicatedRecipe)
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Recipe duplicate failed')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const resetEditing = () => {
+    setActiveRecipeId(null)
+    setRecipeName('')
+    setError(null)
   }
 
   return (
@@ -122,8 +183,13 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
           />
         </label>
         <button type="button" onClick={saveRecipe} disabled={isLoading}>
-          Save
+          {activeRecipeId ? 'Update' : 'Save'}
         </button>
+        {activeRecipeId && (
+          <button type="button" onClick={resetEditing} disabled={isLoading}>
+            Cancel
+          </button>
+        )}
       </div>
 
       {error && <p className="error-message">{error}</p>}
@@ -137,7 +203,9 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
               key={recipe.id}
               recipe={recipe}
               isDisabled={isLoading}
-              onOpen={openRecipe}
+              onLoad={loadRecipe}
+              onEdit={editRecipe}
+              onDuplicate={duplicateRecipe}
               onDelete={removeRecipe}
             />
           ))
@@ -153,4 +221,24 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
       )}
     </section>
   )
+}
+
+function buildDuplicateRecipeName(name: string, recipes: Recipe[]) {
+  const trimmedName = name.trim()
+  const existingNames = new Set(recipes.map((recipe) => recipe.name))
+  const baseName = `${trimmedName} copy`
+
+  if (!existingNames.has(baseName)) {
+    return baseName
+  }
+
+  let copyIndex = 2
+  let nextName = `${trimmedName} copy ${copyIndex}`
+
+  while (existingNames.has(nextName)) {
+    copyIndex += 1
+    nextName = `${trimmedName} copy ${copyIndex}`
+  }
+
+  return nextName
 }

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -106,9 +106,9 @@ export function RecipeManager({
     }
   }
 
-  const removeRecipe = async (id: string) => {
+  const removeRecipe = async (id: string, errorTarget: 'panel' | 'modal' = 'panel') => {
     setIsLoading(true)
-    setPanelError(null)
+    clearError(errorTarget)
 
     try {
       await deleteRecipe(id)
@@ -122,7 +122,10 @@ export function RecipeManager({
         resetModal()
       }
     } catch (caught) {
-      setPanelError(caught instanceof Error ? caught.message : 'Recipe delete failed')
+      setErrorMessage(
+        errorTarget,
+        caught instanceof Error ? caught.message : 'Recipe delete failed',
+      )
     } finally {
       setIsLoading(false)
     }
@@ -289,7 +292,7 @@ export function RecipeManager({
               isActive={recipe.id === activeRecipeId}
               isDisabled={isLoading}
               onSelect={openRecipe}
-              onDelete={(recipeId) => void removeRecipe(recipeId)}
+              onDelete={(recipeId) => void removeRecipe(recipeId, 'panel')}
             />
           ))
         )}
@@ -315,7 +318,7 @@ export function RecipeManager({
           onDuplicate={startDuplicateRecipe}
           onPreview={previewModalRecipe}
           onSave={saveModalRecipe}
-          onDelete={() => void removeRecipe(preview.recipe.id)}
+          onDelete={() => void removeRecipe(preview.recipe.id, 'modal')}
           onCancelEdit={resetModal}
           onClose={resetModal}
         />

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -279,6 +279,7 @@ export function RecipeManager({
               isActive={recipe.id === activeRecipeId}
               isDisabled={isLoading}
               onSelect={openRecipe}
+              onDelete={(recipeId) => void removeRecipe(recipeId)}
             />
           ))
         )}

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -19,14 +19,13 @@ type RecipeManagerProps = {
   setForm: Dispatch<SetStateAction<FormState>>
   compatiblePresets: PresetMetadata[]
   selectedPreset: PresetMetadata | undefined
-  calculationError: string | null
   formula: DoughCalculationRequest
   onLoadRecipe: (formula: DoughCalculationRequest) => void
 }
 
 type RecipePreview = {
   recipe: Recipe
-  result: DoughCalculationResponse
+  result: DoughCalculationResponse | null
 }
 
 type ModalMode = 'view' | 'edit' | 'duplicate'
@@ -37,7 +36,6 @@ export function RecipeManager({
   setForm,
   compatiblePresets,
   selectedPreset,
-  calculationError,
   formula,
   onLoadRecipe,
 }: RecipeManagerProps) {
@@ -130,21 +128,27 @@ export function RecipeManager({
     }
   }
 
-  const showRecipe = async (recipe: Recipe) => {
+  const showRecipe = async (recipe: Recipe, errorTarget: 'panel' | 'modal' = 'panel') => {
     setIsLoading(true)
-    setPanelError(null)
+    clearError(errorTarget)
 
     try {
       const result = await calculateDough(recipe.formula)
       setPreview({ recipe, result })
+      return true
     } catch (caught) {
-      setPanelError(caught instanceof Error ? caught.message : 'Recipe calculation failed')
+      setPreview({ recipe, result: null })
+      setErrorMessage(
+        errorTarget,
+        caught instanceof Error ? caught.message : 'Recipe calculation failed',
+      )
+      return false
     } finally {
       setIsLoading(false)
     }
   }
 
-  const openRecipe = async (recipe: Recipe) => {
+  const openRecipe = async (recipe: Recipe, errorTarget: 'panel' | 'modal' = 'panel') => {
     setPanelError(null)
     setModalError(null)
     setLoadedRecipe(recipe)
@@ -153,7 +157,7 @@ export function RecipeManager({
     setSourceRecipeName(null)
     setModalRecipeName(recipe.name)
     onLoadRecipe(recipe.formula)
-    await showRecipe(recipe)
+    return showRecipe(recipe, errorTarget)
   }
 
   const startEditingRecipe = () => {
@@ -209,7 +213,7 @@ export function RecipeManager({
           ? [savedRecipe, ...currentRecipes]
           : currentRecipes.map((recipe) => (recipe.id === savedRecipe.id ? savedRecipe : recipe)),
       )
-      await openRecipe(savedRecipe)
+      await openRecipe(savedRecipe, 'modal')
     } catch (caught) {
       setModalError(
         caught instanceof Error
@@ -300,7 +304,8 @@ export function RecipeManager({
           setForm={setForm}
           compatiblePresets={compatiblePresets}
           selectedPreset={selectedPreset}
-          formError={modalError ?? calculationError}
+          formError={modalError}
+          resultError={modalError}
           onChangeName={setModalRecipeName}
           onEdit={startEditingRecipe}
           onDuplicate={startDuplicateRecipe}
@@ -324,6 +329,24 @@ export function RecipeManager({
     setModalRecipeName('')
     setSourceRecipeName(null)
     setModalError(null)
+  }
+
+  function clearError(target: 'panel' | 'modal') {
+    if (target === 'modal') {
+      setModalError(null)
+      return
+    }
+
+    setPanelError(null)
+  }
+
+  function setErrorMessage(target: 'panel' | 'modal', message: string) {
+    if (target === 'modal') {
+      setModalError(message)
+      return
+    }
+
+    setPanelError(message)
   }
 }
 

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -50,7 +50,8 @@ export function RecipeManager({
   const [modalRecipeName, setModalRecipeName] = useState('')
   const [sourceRecipeName, setSourceRecipeName] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [panelError, setPanelError] = useState<string | null>(null)
+  const [modalError, setModalError] = useState<string | null>(null)
 
   // While the modal is in edit or duplicate mode, keep the preview card in sync
   // with the draft name and formula the user is currently adjusting.
@@ -73,7 +74,7 @@ export function RecipeManager({
       })
       .catch((caught) => {
         if (isMounted) {
-          setError(caught instanceof Error ? caught.message : 'Recipes request failed')
+          setPanelError(caught instanceof Error ? caught.message : 'Recipes request failed')
         }
       })
 
@@ -88,12 +89,12 @@ export function RecipeManager({
     const name = newRecipeName.trim()
 
     if (!name) {
-      setError('Recipe name is required')
+      setPanelError('Recipe name is required')
       return
     }
 
     setIsLoading(true)
-    setError(null)
+    setPanelError(null)
 
     try {
       const savedRecipe = await createRecipe({ name, formula })
@@ -101,7 +102,7 @@ export function RecipeManager({
       setNewRecipeName('')
       await openRecipe(savedRecipe)
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Recipe save failed')
+      setPanelError(caught instanceof Error ? caught.message : 'Recipe save failed')
     } finally {
       setIsLoading(false)
     }
@@ -109,7 +110,7 @@ export function RecipeManager({
 
   const removeRecipe = async (id: string) => {
     setIsLoading(true)
-    setError(null)
+    setPanelError(null)
 
     try {
       await deleteRecipe(id)
@@ -123,7 +124,7 @@ export function RecipeManager({
         resetModal()
       }
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Recipe delete failed')
+      setPanelError(caught instanceof Error ? caught.message : 'Recipe delete failed')
     } finally {
       setIsLoading(false)
     }
@@ -131,20 +132,21 @@ export function RecipeManager({
 
   const showRecipe = async (recipe: Recipe) => {
     setIsLoading(true)
-    setError(null)
+    setPanelError(null)
 
     try {
       const result = await calculateDough(recipe.formula)
       setPreview({ recipe, result })
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Recipe calculation failed')
+      setPanelError(caught instanceof Error ? caught.message : 'Recipe calculation failed')
     } finally {
       setIsLoading(false)
     }
   }
 
   const openRecipe = async (recipe: Recipe) => {
-    setError(null)
+    setPanelError(null)
+    setModalError(null)
     setLoadedRecipe(recipe)
     setActiveRecipeId(recipe.id)
     setModalMode('view')
@@ -159,7 +161,7 @@ export function RecipeManager({
       return
     }
 
-    setError(null)
+    setModalError(null)
     setModalMode('edit')
     setModalRecipeName(loadedRecipe.name)
     setSourceRecipeName(null)
@@ -174,7 +176,7 @@ export function RecipeManager({
 
     const duplicateName = buildDuplicateRecipeName(loadedRecipe.name, recipes)
 
-    setError(null)
+    setModalError(null)
     setModalMode('duplicate')
     setSourceRecipeName(loadedRecipe.name)
     setModalRecipeName(duplicateName)
@@ -189,12 +191,12 @@ export function RecipeManager({
     const name = modalRecipeName.trim()
 
     if (!name) {
-      setError('Recipe name is required')
+      setModalError('Recipe name is required')
       return
     }
 
     setIsLoading(true)
-    setError(null)
+    setModalError(null)
 
     try {
       const savedRecipe =
@@ -209,7 +211,7 @@ export function RecipeManager({
       )
       await openRecipe(savedRecipe)
     } catch (caught) {
-      setError(
+      setModalError(
         caught instanceof Error
           ? caught.message
           : modalMode === 'duplicate'
@@ -227,7 +229,7 @@ export function RecipeManager({
     }
 
     setIsLoading(true)
-    setError(null)
+    setModalError(null)
 
     try {
       const result = await calculateDough(formula)
@@ -236,7 +238,7 @@ export function RecipeManager({
         result,
       })
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Recipe calculation failed')
+      setModalError(caught instanceof Error ? caught.message : 'Recipe calculation failed')
     } finally {
       setIsLoading(false)
     }
@@ -266,7 +268,7 @@ export function RecipeManager({
         </button>
       </div>
 
-      {error && <p className="error-message">{error}</p>}
+      {panelError && <p className="error-message">{panelError}</p>}
 
       <div className="recipe-list">
         {recipes.length === 0 ? (
@@ -298,7 +300,7 @@ export function RecipeManager({
           setForm={setForm}
           compatiblePresets={compatiblePresets}
           selectedPreset={selectedPreset}
-          formError={calculationError}
+          formError={modalError ?? calculationError}
           onChangeName={setModalRecipeName}
           onEdit={startEditingRecipe}
           onDuplicate={startDuplicateRecipe}
@@ -321,7 +323,7 @@ export function RecipeManager({
     setModalMode('view')
     setModalRecipeName('')
     setSourceRecipeName(null)
-    setError(null)
+    setModalError(null)
   }
 }
 

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -1,12 +1,25 @@
-import { useEffect, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { calculateDough } from '../api/doughApi'
 import { createRecipe, deleteRecipe, fetchRecipes, updateRecipe } from '../api/recipeApi'
-import type { DoughCalculationRequest, DoughCalculationResponse } from '../types/dough'
+import type {
+  DoughCalculationRequest,
+  DoughCalculationResponse,
+  DoughMetadata,
+  FormState,
+  PresetMetadata,
+} from '../types/dough'
 import type { Recipe } from '../types/recipe'
 import { RecipeDetailModal } from './RecipeDetailModal'
 import { RecipeListItem } from './RecipeListItem'
 
 type RecipeManagerProps = {
+  metadata: DoughMetadata
+  form: FormState
+  setForm: Dispatch<SetStateAction<FormState>>
+  compatiblePresets: PresetMetadata[]
+  selectedPreset: PresetMetadata | undefined
+  calculationError: string | null
   formula: DoughCalculationRequest
   onLoadRecipe: (formula: DoughCalculationRequest) => void
 }
@@ -16,13 +29,43 @@ type RecipePreview = {
   result: DoughCalculationResponse
 }
 
-export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
+type ModalMode = 'view' | 'edit' | 'duplicate'
+
+export function RecipeManager({
+  metadata,
+  form,
+  setForm,
+  compatiblePresets,
+  selectedPreset,
+  calculationError,
+  formula,
+  onLoadRecipe,
+}: RecipeManagerProps) {
   const [recipes, setRecipes] = useState<Recipe[]>([])
   const [preview, setPreview] = useState<RecipePreview | null>(null)
-  const [recipeName, setRecipeName] = useState('')
+  const [newRecipeName, setNewRecipeName] = useState('')
   const [activeRecipeId, setActiveRecipeId] = useState<string | null>(null)
+  const [modalMode, setModalMode] = useState<ModalMode>('view')
+  const [modalRecipeName, setModalRecipeName] = useState('')
+  const [sourceRecipeName, setSourceRecipeName] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  const modalRecipe = useMemo(() => {
+    if (!preview) {
+      return null
+    }
+
+    if (modalMode === 'view') {
+      return preview.recipe
+    }
+
+    return {
+      ...preview.recipe,
+      name: modalRecipeName.trim() || preview.recipe.name,
+      formula,
+    }
+  }, [formula, modalMode, modalRecipeName, preview])
 
   useEffect(() => {
     let isMounted = true
@@ -46,8 +89,8 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
 
   // Recipes persist the formula input. Ingredient details are calculated on demand
   // so the modal always uses the same calculator logic as the main results panel.
-  const saveRecipe = async () => {
-    const name = recipeName.trim()
+  const saveNewRecipe = async () => {
+    const name = newRecipeName.trim()
 
     if (!name) {
       setError('Recipe name is required')
@@ -58,26 +101,12 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
     setError(null)
 
     try {
-      const savedRecipe = activeRecipeId
-        ? await updateRecipe(activeRecipeId, { name, formula })
-        : await createRecipe({ name, formula })
-
-      setRecipes((currentRecipes) =>
-        activeRecipeId
-          ? currentRecipes.map((recipe) => (recipe.id === savedRecipe.id ? savedRecipe : recipe))
-          : [savedRecipe, ...currentRecipes],
-      )
-      setActiveRecipeId(savedRecipe.id)
-      setRecipeName(savedRecipe.name)
-      await loadRecipe(savedRecipe)
+      const savedRecipe = await createRecipe({ name, formula })
+      setRecipes((currentRecipes) => [savedRecipe, ...currentRecipes])
+      setNewRecipeName('')
+      await openRecipe(savedRecipe)
     } catch (caught) {
-      setError(
-        caught instanceof Error
-          ? caught.message
-          : activeRecipeId
-            ? 'Recipe update failed'
-            : 'Recipe save failed',
-      )
+      setError(caught instanceof Error ? caught.message : 'Recipe save failed')
     } finally {
       setIsLoading(false)
     }
@@ -93,7 +122,9 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
       setPreview((currentPreview) => (currentPreview?.recipe.id === id ? null : currentPreview))
       if (activeRecipeId === id) {
         setActiveRecipeId(null)
-        setRecipeName('')
+      }
+      if (preview?.recipe.id === id) {
+        resetModal()
       }
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Recipe delete failed')
@@ -117,50 +148,106 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
   }
 
   const openRecipe = async (recipe: Recipe) => {
+    setError(null)
     setActiveRecipeId(recipe.id)
-    setRecipeName(recipe.name)
+    setModalMode('view')
+    setSourceRecipeName(null)
+    setModalRecipeName(recipe.name)
     onLoadRecipe(recipe.formula)
     await showRecipe(recipe)
   }
 
-  const loadRecipe = async (recipe: Recipe) => {
-    await openRecipe(recipe)
+  const startEditingRecipe = () => {
+    if (!preview) {
+      return
+    }
+
+    setError(null)
+    setModalMode('edit')
+    setModalRecipeName(preview.recipe.name)
+    setSourceRecipeName(null)
+    setActiveRecipeId(preview.recipe.id)
+    onLoadRecipe(preview.recipe.formula)
   }
 
-  const editRecipe = (recipe: Recipe) => {
+  const startDuplicateRecipe = () => {
+    if (!preview) {
+      return
+    }
+
+    const recipe = preview.recipe
+    const duplicateName = buildDuplicateRecipeName(recipe.name, recipes)
+
     setError(null)
-    setActiveRecipeId(recipe.id)
-    setRecipeName(recipe.name)
+    setModalMode('duplicate')
+    setSourceRecipeName(recipe.name)
+    setModalRecipeName(duplicateName)
     onLoadRecipe(recipe.formula)
   }
 
-  const duplicateRecipe = async (recipe: Recipe) => {
-    const duplicateName = buildDuplicateRecipeName(recipe.name, recipes)
+  const saveModalRecipe = async () => {
+    if (!preview) {
+      return
+    }
+
+    const name = modalRecipeName.trim()
+
+    if (!name) {
+      setError('Recipe name is required')
+      return
+    }
 
     setIsLoading(true)
     setError(null)
 
     try {
-      const duplicatedRecipe = await createRecipe({
-        name: duplicateName,
-        formula: recipe.formula,
-      })
-      setRecipes((currentRecipes) => [duplicatedRecipe, ...currentRecipes])
-      setActiveRecipeId(duplicatedRecipe.id)
-      setRecipeName(duplicatedRecipe.name)
-      onLoadRecipe(duplicatedRecipe.formula)
-      await showRecipe(duplicatedRecipe)
+      const savedRecipe =
+        modalMode === 'duplicate'
+          ? await createRecipe({ name, formula })
+          : await updateRecipe(preview.recipe.id, { name, formula })
+
+      setRecipes((currentRecipes) =>
+        modalMode === 'duplicate'
+          ? [savedRecipe, ...currentRecipes]
+          : currentRecipes.map((recipe) => (recipe.id === savedRecipe.id ? savedRecipe : recipe)),
+      )
+      await openRecipe(savedRecipe)
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Recipe duplicate failed')
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : modalMode === 'duplicate'
+            ? 'Recipe duplicate failed'
+            : 'Recipe update failed',
+      )
     } finally {
       setIsLoading(false)
     }
   }
 
-  const resetEditing = () => {
-    setActiveRecipeId(null)
-    setRecipeName('')
+  const previewModalRecipe = async () => {
+    if (!preview) {
+      return
+    }
+
+    setIsLoading(true)
     setError(null)
+
+    try {
+      const result = await calculateDough(formula)
+      setPreview({
+        recipe: {
+          ...preview.recipe,
+          name: modalRecipeName.trim() || preview.recipe.name,
+          formula,
+        },
+        result,
+      })
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Recipe calculation failed')
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (
@@ -177,19 +264,14 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
         <label>
           <span>Name</span>
           <input
-            value={recipeName}
-            onChange={(event) => setRecipeName(event.target.value)}
+            value={newRecipeName}
+            onChange={(event) => setNewRecipeName(event.target.value)}
             placeholder="24h room direct"
           />
         </label>
-        <button type="button" onClick={saveRecipe} disabled={isLoading}>
-          {activeRecipeId ? 'Update' : 'Save'}
+        <button type="button" onClick={saveNewRecipe} disabled={isLoading}>
+          Save current
         </button>
-        {activeRecipeId && (
-          <button type="button" onClick={resetEditing} disabled={isLoading}>
-            Cancel
-          </button>
-        )}
       </div>
 
       {error && <p className="error-message">{error}</p>}
@@ -202,11 +284,9 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
             <RecipeListItem
               key={recipe.id}
               recipe={recipe}
+              isActive={recipe.id === activeRecipeId}
               isDisabled={isLoading}
-              onLoad={loadRecipe}
-              onEdit={editRecipe}
-              onDuplicate={duplicateRecipe}
-              onDelete={removeRecipe}
+              onSelect={openRecipe}
             />
           ))
         )}
@@ -214,13 +294,38 @@ export function RecipeManager({ formula, onLoadRecipe }: RecipeManagerProps) {
 
       {preview && (
         <RecipeDetailModal
-          recipe={preview.recipe}
+          recipe={modalRecipe ?? preview.recipe}
           result={preview.result}
-          onClose={() => setPreview(null)}
+          mode={modalMode}
+          recipeName={modalRecipeName}
+          sourceRecipeName={sourceRecipeName}
+          isLoading={isLoading}
+          metadata={metadata}
+          form={form}
+          setForm={setForm}
+          compatiblePresets={compatiblePresets}
+          selectedPreset={selectedPreset}
+          formError={calculationError}
+          onChangeName={setModalRecipeName}
+          onEdit={startEditingRecipe}
+          onDuplicate={startDuplicateRecipe}
+          onPreview={previewModalRecipe}
+          onSave={saveModalRecipe}
+          onDelete={() => void removeRecipe(preview.recipe.id)}
+          onCancelEdit={resetModal}
+          onClose={resetModal}
         />
       )}
     </section>
   )
+
+  function resetModal() {
+    setPreview(null)
+    setModalMode('view')
+    setModalRecipeName('')
+    setSourceRecipeName(null)
+    setError(null)
+  }
 }
 
 function buildDuplicateRecipeName(name: string, recipes: Recipe[]) {

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -128,7 +128,7 @@ export function RecipeManager({
     }
   }
 
-  const showRecipe = async (recipe: Recipe, errorTarget: 'panel' | 'modal' = 'panel') => {
+  const showRecipe = async (recipe: Recipe, errorTarget: 'panel' | 'modal' = 'modal') => {
     setIsLoading(true)
     clearError(errorTarget)
 
@@ -148,7 +148,7 @@ export function RecipeManager({
     }
   }
 
-  const openRecipe = async (recipe: Recipe, errorTarget: 'panel' | 'modal' = 'panel') => {
+  const openRecipe = async (recipe: Recipe, errorTarget: 'panel' | 'modal' = 'modal') => {
     setPanelError(null)
     setModalError(null)
     setLoadedRecipe(recipe)

--- a/frontend/src/components/RecipeManager.tsx
+++ b/frontend/src/components/RecipeManager.tsx
@@ -242,6 +242,10 @@ export function RecipeManager({
         result,
       })
     } catch (caught) {
+      setPreview({
+        recipe: buildModalRecipe(preview.recipe, modalMode, modalRecipeName, formula),
+        result: null,
+      })
       setModalError(caught instanceof Error ? caught.message : 'Recipe calculation failed')
     } finally {
       setIsLoading(false)

--- a/frontend/src/utils/recipeForm.ts
+++ b/frontend/src/utils/recipeForm.ts
@@ -1,0 +1,29 @@
+import type { DoughCalculationRequest, FormState } from '../types/dough'
+
+export function applyRecipeFormulaToForm(
+  current: FormState,
+  formula: DoughCalculationRequest,
+): FormState {
+  return {
+    ...current,
+    pizzaCount: formula.pizzaCount,
+    doughBallWeightGrams: formula.doughBallWeightGrams,
+    hydrationPercent: formula.hydrationPercent,
+    saltPercent: formula.saltPercent,
+    yeastType: formula.yeastType,
+    doughMethod: formula.doughMethod,
+    fermentationPreset: formula.fermentationSchedule
+      ? null
+      : formula.fermentationPreset ?? current.fermentationPreset,
+    fermentationSchedule: formula.fermentationSchedule ?? null,
+    roomTemperatureCelsius:
+      formula.roomTemperatureCelsius ??
+      formula.fermentationSchedule?.roomTemperatureCelsius ??
+      current.roomTemperatureCelsius,
+    coldTemperatureCelsius:
+      formula.coldTemperatureCelsius ??
+      formula.fermentationSchedule?.coldTemperatureCelsius ??
+      current.coldTemperatureCelsius,
+    prefermentFlourPercent: formula.prefermentFlourPercent ?? current.prefermentFlourPercent,
+  }
+}


### PR DESCRIPTION
## Summary
- add backend recipe update support and keep recipe load/edit/duplicate flows consistent
- rework the frontend recipe UX so recipes open on click and full recipe editing happens in the modal
- add coverage for the load/edit/duplicate flow and refactor shared recipe-form helpers for cleaner code

## Testing
- `./gradlew backend:test --tests com.pizzalab.backend.api.recipe.RecipeControllerTest`
- `npm test`
- `npm run build`