### PR TITLE
Implement fermentation timeline panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,7 +50,7 @@ function App() {
             isLoading={isLoading}
             onSubmit={calculate}
           />
-          <ResultsPanel result={result} />
+          <ResultsPanel result={result} form={form} selectedPreset={selectedPreset} />
         </section>
 
         <RecipeManager

--- a/frontend/src/components/FermentationTimelinePanel/FermentationTimelinePanel.scss
+++ b/frontend/src/components/FermentationTimelinePanel/FermentationTimelinePanel.scss
@@ -1,0 +1,117 @@
+@use '../../styles/tokens' as *;
+
+.timeline-panel {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid $color-border-panel;
+}
+
+.timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.timeline-header h3 {
+  color: $color-text-strong;
+  font-size: 22px;
+  line-height: 1.1;
+}
+
+.timeline-summary {
+  padding: 7px 9px;
+  border-radius: 999px;
+  background: $color-surface-muted;
+  color: $color-text-soft;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.timeline-list {
+  display: grid;
+  gap: 12px;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.timeline-marker {
+  position: relative;
+  width: 16px;
+  height: 16px;
+  margin-top: 3px;
+  border: 3px solid $color-brand-soft;
+  border-radius: 999px;
+  background: $color-surface-panel;
+}
+
+.timeline-item:not(:last-child) .timeline-marker::after {
+  content: '';
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  width: 1px;
+  height: calc(100% + 26px);
+  transform: translateX(-50%);
+  background: $color-border-panel;
+}
+
+.timeline-content {
+  min-width: 0;
+  padding: 12px 14px;
+  border: 1px solid $color-border-panel;
+  border-radius: $radius-sm;
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.timeline-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+}
+
+.timeline-row strong {
+  color: $color-text-strong;
+  font-size: 15px;
+}
+
+.timeline-row span {
+  color: $color-text-soft;
+  font-size: 13px;
+  text-align: right;
+}
+
+.timeline-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.timeline-meta span {
+  padding: 6px 8px;
+  border-radius: 999px;
+  background: $color-surface-muted;
+  color: $color-text-soft;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+@media (max-width: $breakpoint-tablet) {
+  .timeline-header,
+  .timeline-row {
+    flex-direction: column;
+  }
+
+  .timeline-row span {
+    text-align: left;
+  }
+}

--- a/frontend/src/components/FermentationTimelinePanel/FermentationTimelinePanel.tsx
+++ b/frontend/src/components/FermentationTimelinePanel/FermentationTimelinePanel.tsx
@@ -1,0 +1,52 @@
+import './FermentationTimelinePanel.scss'
+import type { FormState, PresetMetadata } from '../../types/dough'
+import {
+  buildFermentationTimeline,
+  getTimelineSummaryLabel,
+} from '../../utils/fermentationTimeline'
+
+type FermentationTimelinePanelProps = {
+  form: FormState
+  selectedPreset: PresetMetadata | undefined
+  startedAt?: Date
+}
+
+export function FermentationTimelinePanel({
+  form,
+  selectedPreset,
+  startedAt,
+}: FermentationTimelinePanelProps) {
+  const entries = buildFermentationTimeline(form, selectedPreset, startedAt)
+
+  return (
+    <section className="timeline-panel" aria-labelledby="timeline-title">
+      <div className="timeline-header">
+        <div>
+          <p className="section-title">Timeline</p>
+          <h3 id="timeline-title">From mixing to bake</h3>
+        </div>
+        <span className="timeline-summary">{getTimelineSummaryLabel(form)}</span>
+      </div>
+
+      <ol className="timeline-list">
+        {entries.map((entry) => (
+          <li key={entry.key} className="timeline-item">
+            <div className="timeline-marker" aria-hidden="true" />
+            <div className="timeline-content">
+              <div className="timeline-row">
+                <strong>{entry.title}</strong>
+                <span>{entry.timestamp}</span>
+              </div>
+              {(entry.durationLabel || entry.timeRangeLabel) && (
+                <div className="timeline-meta">
+                  {entry.durationLabel && <span>{entry.durationLabel}</span>}
+                  {entry.timeRangeLabel && <span>{entry.timeRangeLabel}</span>}
+                </div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}

--- a/frontend/src/components/FermentationTimelinePanel/index.ts
+++ b/frontend/src/components/FermentationTimelinePanel/index.ts
@@ -1,0 +1,1 @@
+export { FermentationTimelinePanel } from './FermentationTimelinePanel'

--- a/frontend/src/components/ResultsPanel/ResultsPanel.test.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.test.tsx
@@ -1,25 +1,46 @@
 // @vitest-environment jsdom
 
 import { useMemo, useState } from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defaultForm, defaultMetadata } from '../../data/doughDefaults'
 import type { FormState } from '../../types/dough'
 import { DoughForm } from '../DoughForm'
 import { ResultsPanel } from './ResultsPanel'
 
+afterEach(() => {
+  cleanup()
+})
+
 describe('ResultsPanel', () => {
+  it('keeps the fermentation timeline outside the live results region', () => {
+    render(<ResultsPanelHarness />)
+
+    const liveRegion = document.querySelector('.results-live-region')
+
+    expect(liveRegion?.getAttribute('aria-live')).toBe('polite')
+    expect(liveRegion?.textContent).not.toContain('Timeline')
+    expect(screen.getByText('Timeline')).toBeTruthy()
+  })
+
   it('updates fermentation timeline immediately when form changes', async () => {
     const user = userEvent.setup()
 
-    render(<ResultsPanelHarness />)
+    const { container } = render(<ResultsPanelHarness />)
+    const resultsPanel = container.querySelector<HTMLElement>('.results-panel')
 
-    expect(screen.getByText('Mix dough')).toBeTruthy()
-    expect(screen.getByText('Cold ferment')).toBeTruthy()
-    expect(screen.getByText('24h at 5C')).toBeTruthy()
-    expect(screen.getByText('30 Apr · 09:30 to 1 May · 09:30')).toBeTruthy()
-    expect(screen.queryByText('Final mix')).toBeNull()
+    if (!resultsPanel) {
+      throw new Error('Missing results panel')
+    }
+
+    const results = within(resultsPanel)
+
+    expect(results.getByText('Mix dough')).toBeTruthy()
+    expect(results.getByText('Cold ferment')).toBeTruthy()
+    expect(results.getByText('24h at 5C')).toBeTruthy()
+    expect(results.getByText('30 Apr · 09:30 to 1 May · 09:30')).toBeTruthy()
+    expect(results.queryByText('Final mix')).toBeNull()
 
     await user.click(screen.getByRole('button', { name: 'Manual' }))
     await user.click(screen.getByRole('button', { name: 'Poolish' }))
@@ -30,14 +51,14 @@ describe('ResultsPanel', () => {
     await user.type(screen.getByRole('spinbutton', { name: 'Cold hours h' }), '24')
 
     await waitFor(() => {
-      expect(screen.getByText('Mix poolish')).toBeTruthy()
-      expect(screen.getByText('Ferment poolish')).toBeTruthy()
-      expect(screen.getByText('Final mix')).toBeTruthy()
-      expect(screen.getByText('16h at 20C')).toBeTruthy()
-      expect(screen.getByText('24h at 5C')).toBeTruthy()
-      expect(screen.getByText('30 Apr · 09:30 to 1 May · 01:30')).toBeTruthy()
-      expect(screen.getByText('1 May · 01:30 to 2 May · 01:30')).toBeTruthy()
-      expect(screen.getAllByText('2 May · 01:30')).toHaveLength(2)
+      expect(results.getByText('Mix poolish')).toBeTruthy()
+      expect(results.getByText('Ferment poolish')).toBeTruthy()
+      expect(results.getByText('Final mix')).toBeTruthy()
+      expect(results.getByText('16h at 20C')).toBeTruthy()
+      expect(results.getByText('24h at 5C')).toBeTruthy()
+      expect(results.getByText('30 Apr · 09:30 to 1 May · 01:30')).toBeTruthy()
+      expect(results.getByText('1 May · 01:30 to 2 May · 01:30')).toBeTruthy()
+      expect(results.getAllByText('2 May · 01:30')).toHaveLength(2)
     })
   })
 })

--- a/frontend/src/components/ResultsPanel/ResultsPanel.test.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { useMemo, useState } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { defaultForm, defaultMetadata } from '../../data/doughDefaults'
+import type { FormState } from '../../types/dough'
+import { DoughForm } from '../DoughForm'
+import { ResultsPanel } from './ResultsPanel'
+
+describe('ResultsPanel', () => {
+  it('updates fermentation timeline immediately when form changes', async () => {
+    const user = userEvent.setup()
+
+    render(<ResultsPanelHarness />)
+
+    expect(screen.getByText('Mix dough')).toBeTruthy()
+    expect(screen.getByText('Cold ferment')).toBeTruthy()
+    expect(screen.getByText('24h at 5C')).toBeTruthy()
+    expect(screen.getByText('30 Apr · 09:30 to 1 May · 09:30')).toBeTruthy()
+    expect(screen.queryByText('Final mix')).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'Manual' }))
+    await user.click(screen.getByRole('button', { name: 'Poolish' }))
+
+    await user.clear(screen.getByRole('spinbutton', { name: 'Room hours h' }))
+    await user.type(screen.getByRole('spinbutton', { name: 'Room hours h' }), '16')
+    await user.clear(screen.getByRole('spinbutton', { name: 'Cold hours h' }))
+    await user.type(screen.getByRole('spinbutton', { name: 'Cold hours h' }), '24')
+
+    await waitFor(() => {
+      expect(screen.getByText('Mix poolish')).toBeTruthy()
+      expect(screen.getByText('Ferment poolish')).toBeTruthy()
+      expect(screen.getByText('Final mix')).toBeTruthy()
+      expect(screen.getByText('16h at 20C')).toBeTruthy()
+      expect(screen.getByText('24h at 5C')).toBeTruthy()
+      expect(screen.getByText('30 Apr · 09:30 to 1 May · 01:30')).toBeTruthy()
+      expect(screen.getByText('1 May · 01:30 to 2 May · 01:30')).toBeTruthy()
+      expect(screen.getAllByText('2 May · 01:30')).toHaveLength(2)
+    })
+  })
+})
+
+function ResultsPanelHarness() {
+  const [form, setForm] = useState<FormState>(defaultForm)
+  const compatiblePresets = useMemo(
+    () =>
+      defaultMetadata.fermentationPresets.filter((preset) =>
+        preset.compatibleDoughMethods.includes(form.doughMethod),
+      ),
+    [form.doughMethod],
+  )
+  const selectedPreset = form.fermentationSchedule
+    ? undefined
+    : compatiblePresets.find((preset) => preset.code === form.fermentationPreset) ??
+      compatiblePresets[0]
+
+  return (
+    <>
+      <DoughForm
+        metadata={defaultMetadata}
+        form={form}
+        setForm={setForm}
+        compatiblePresets={compatiblePresets}
+        selectedPreset={selectedPreset}
+        error={null}
+        isLoading={false}
+        onSubmit={vi.fn()}
+      />
+      <ResultsPanel
+        result={null}
+        form={form}
+        selectedPreset={selectedPreset}
+        timelineStartedAt={new Date(2026, 3, 30, 9, 30)}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.tsx
@@ -1,16 +1,30 @@
 import './ResultsPanel.scss'
 import { DoughResultBreakdown } from '../DoughResultBreakdown'
-import type { DoughCalculationResponse } from '../../types/dough'
+import { FermentationTimelinePanel } from '../FermentationTimelinePanel'
+import type { DoughCalculationResponse, FormState, PresetMetadata } from '../../types/dough'
 import { formatGram } from '../../utils/format'
 
 type ResultsPanelProps = {
   result: DoughCalculationResponse | null
+  form: FormState
+  selectedPreset: PresetMetadata | undefined
+  timelineStartedAt?: Date
 }
 
-export function ResultsPanel({ result }: ResultsPanelProps) {
+export function ResultsPanel({
+  result,
+  form,
+  selectedPreset,
+  timelineStartedAt,
+}: ResultsPanelProps) {
   return (
     <section className="results-panel" aria-live="polite">
       {result ? <Results result={result} /> : <EmptyResults />}
+      <FermentationTimelinePanel
+        form={form}
+        selectedPreset={selectedPreset}
+        startedAt={timelineStartedAt}
+      />
     </section>
   )
 }

--- a/frontend/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.tsx
@@ -18,8 +18,10 @@ export function ResultsPanel({
   timelineStartedAt,
 }: ResultsPanelProps) {
   return (
-    <section className="results-panel" aria-live="polite">
-      {result ? <Results result={result} /> : <EmptyResults />}
+    <section className="results-panel">
+      <div className="results-live-region" aria-live="polite">
+        {result ? <Results result={result} /> : <EmptyResults />}
+      </div>
       <FermentationTimelinePanel
         form={form}
         selectedPreset={selectedPreset}

--- a/frontend/src/utils/fermentationTimeline.test.ts
+++ b/frontend/src/utils/fermentationTimeline.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { defaultForm, defaultMetadata } from '../data/doughDefaults'
+import type { FormState } from '../types/dough'
+import { buildFermentationTimeline } from './fermentationTimeline'
+
+describe('buildFermentationTimeline', () => {
+  it('uses preset values for direct cold fermentation', () => {
+    const startedAt = new Date(2026, 3, 30, 9, 30)
+    const form: FormState = {
+      ...defaultForm,
+      doughMethod: 'DIRECT',
+      fermentationPreset: 'COLD_24H',
+      fermentationSchedule: null,
+      coldTemperatureCelsius: 5,
+    }
+    const selectedPreset = defaultMetadata.fermentationPresets.find(
+      (preset) => preset.code === 'COLD_24H',
+    )
+
+    const timeline = buildFermentationTimeline(form, selectedPreset, startedAt)
+
+    expect(timeline).toEqual([
+      {
+        key: 'mix',
+        title: 'Mix dough',
+        timestamp: '30 Apr · 09:30',
+      },
+      {
+        key: 'cold-ferment',
+        title: 'Cold ferment',
+        timestamp: '1 May · 09:30',
+        durationLabel: '24h at 5C',
+        timeRangeLabel: '30 Apr · 09:30 to 1 May · 09:30',
+      },
+      {
+        key: 'ready',
+        title: 'Ready to bake',
+        timestamp: '1 May · 09:30',
+      },
+    ])
+  })
+
+  it('builds preferment timeline with final mix for mixed manual schedule', () => {
+    const startedAt = new Date(2026, 3, 30, 8, 0)
+    const form: FormState = {
+      ...defaultForm,
+      doughMethod: 'POOLISH',
+      fermentationPreset: 'POOLISH_ROOM_16H_COLD_24H',
+      fermentationSchedule: {
+        mode: 'MIXED',
+        roomHours: 16,
+        roomTemperatureCelsius: 20,
+        coldHours: 24,
+        coldTemperatureCelsius: 4,
+      },
+      prefermentFlourPercent: 30,
+    }
+
+    const timeline = buildFermentationTimeline(form, undefined, startedAt)
+
+    expect(timeline).toEqual([
+      {
+        key: 'mix-preferment',
+        title: 'Mix poolish',
+        timestamp: '30 Apr · 08:00',
+      },
+      {
+        key: 'preferment-ferment',
+        title: 'Ferment poolish',
+        timestamp: '1 May · 00:00',
+        durationLabel: '16h at 20C',
+        timeRangeLabel: '30 Apr · 08:00 to 1 May · 00:00',
+      },
+      {
+        key: 'final-mix',
+        title: 'Final mix',
+        timestamp: '1 May · 00:00',
+      },
+      {
+        key: 'cold-ferment',
+        title: 'Cold ferment',
+        timestamp: '2 May · 00:00',
+        durationLabel: '24h at 4C',
+        timeRangeLabel: '1 May · 00:00 to 2 May · 00:00',
+      },
+      {
+        key: 'ready',
+        title: 'Ready to bake',
+        timestamp: '2 May · 00:00',
+      },
+    ])
+  })
+})

--- a/frontend/src/utils/fermentationTimeline.ts
+++ b/frontend/src/utils/fermentationTimeline.ts
@@ -15,6 +15,13 @@ type ResolvedFermentationTimeline = {
   coldTemperatureCelsius: number
 }
 
+type TimelineStageDefinition = {
+  key: string
+  title: string
+  durationHours: number
+  temperatureCelsius: number
+}
+
 const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
 export function buildFermentationTimeline(
@@ -28,89 +35,79 @@ export function buildFermentationTimeline(
 
   if (form.doughMethod === 'DIRECT') {
     timeline.push(buildInstantEntry('mix', 'Mix dough', cursor))
-    cursor = appendFermentationStages(timeline, schedule, cursor)
+    cursor = appendStages(timeline, buildDirectStages(schedule), cursor)
     timeline.push(buildInstantEntry('ready', 'Ready to bake', cursor))
     return timeline
   }
 
-  const prefermentLabel = form.doughMethod === 'POOLISH' ? 'poolish' : 'biga'
+  const prefermentLabel = getPrefermentLabel(form.doughMethod)
 
   timeline.push(buildInstantEntry('mix-preferment', `Mix ${prefermentLabel}`, cursor))
-
-  if (schedule.roomHours > 0) {
-    const endAt = addHours(cursor, schedule.roomHours)
-    timeline.push(
-      buildDurationEntry(
-        'preferment-ferment',
-        `Ferment ${prefermentLabel}`,
-        cursor,
-        endAt,
-        schedule.roomHours,
-        schedule.roomTemperatureCelsius,
-      ),
-    )
-    cursor = endAt
-  }
+  cursor = appendStages(timeline, buildPrefermentStages(schedule, prefermentLabel), cursor)
 
   timeline.push(buildInstantEntry('final-mix', 'Final mix', cursor))
-
-  if (schedule.coldHours > 0) {
-    const endAt = addHours(cursor, schedule.coldHours)
-    timeline.push(
-      buildDurationEntry(
-        'cold-ferment',
-        'Cold ferment',
-        cursor,
-        endAt,
-        schedule.coldHours,
-        schedule.coldTemperatureCelsius,
-      ),
-    )
-    cursor = endAt
-  }
+  cursor = appendStages(timeline, buildColdStages(schedule), cursor)
 
   timeline.push(buildInstantEntry('ready', 'Ready to bake', cursor))
   return timeline
 }
 
-function appendFermentationStages(
+function appendStages(
   timeline: FermentationTimelineEntry[],
-  schedule: ResolvedFermentationTimeline,
+  stages: TimelineStageDefinition[],
   startedAt: Date,
 ): Date {
   let cursor = startedAt
 
-  if (schedule.roomHours > 0) {
-    const endAt = addHours(cursor, schedule.roomHours)
+  for (const stage of stages) {
+    const endAt = addHours(cursor, stage.durationHours)
     timeline.push(
-      buildDurationEntry(
-        'room-ferment',
-        'Room ferment',
-        cursor,
-        endAt,
-        schedule.roomHours,
-        schedule.roomTemperatureCelsius,
-      ),
-    )
-    cursor = endAt
-  }
-
-  if (schedule.coldHours > 0) {
-    const endAt = addHours(cursor, schedule.coldHours)
-    timeline.push(
-      buildDurationEntry(
-        'cold-ferment',
-        'Cold ferment',
-        cursor,
-        endAt,
-        schedule.coldHours,
-        schedule.coldTemperatureCelsius,
-      ),
+      buildDurationEntry(stage.key, stage.title, cursor, endAt, stage.durationHours, stage.temperatureCelsius),
     )
     cursor = endAt
   }
 
   return cursor
+}
+
+function buildDirectStages(schedule: ResolvedFermentationTimeline): TimelineStageDefinition[] {
+  return [
+    buildStage('room-ferment', 'Room ferment', schedule.roomHours, schedule.roomTemperatureCelsius),
+    buildStage('cold-ferment', 'Cold ferment', schedule.coldHours, schedule.coldTemperatureCelsius),
+  ].filter(isDefined)
+}
+
+function buildPrefermentStages(
+  schedule: ResolvedFermentationTimeline,
+  prefermentLabel: string,
+): TimelineStageDefinition[] {
+  return [
+    buildStage(
+      'preferment-ferment',
+      `Ferment ${prefermentLabel}`,
+      schedule.roomHours,
+      schedule.roomTemperatureCelsius,
+    ),
+  ].filter(isDefined)
+}
+
+function buildColdStages(schedule: ResolvedFermentationTimeline): TimelineStageDefinition[] {
+  return [buildStage('cold-ferment', 'Cold ferment', schedule.coldHours, schedule.coldTemperatureCelsius)].filter(
+    isDefined,
+  )
+}
+
+function buildStage(
+  key: string,
+  title: string,
+  durationHours: number,
+  temperatureCelsius: number,
+): TimelineStageDefinition | null {
+  if (durationHours <= 0) {
+    return null
+  }
+
+  return { key, title, durationHours, temperatureCelsius }
 }
 
 function resolveFermentationTimeline(
@@ -163,6 +160,14 @@ function buildDurationEntry(
 
 function addHours(date: Date, hours: number): Date {
   return new Date(date.getTime() + hours * 60 * 60 * 1000)
+}
+
+function getPrefermentLabel(method: DoughMethod): 'poolish' | 'biga' {
+  return method === 'POOLISH' ? 'poolish' : 'biga'
+}
+
+function isDefined<T>(value: T | null): value is T {
+  return value !== null
 }
 
 function formatTimelineTimestamp(date: Date): string {

--- a/frontend/src/utils/fermentationTimeline.ts
+++ b/frontend/src/utils/fermentationTimeline.ts
@@ -1,0 +1,205 @@
+import type { DoughMethod, FormState, PresetMetadata } from '../types/dough'
+
+export type FermentationTimelineEntry = {
+  key: string
+  title: string
+  timestamp: string
+  durationLabel?: string
+  timeRangeLabel?: string
+}
+
+type ResolvedFermentationTimeline = {
+  roomHours: number
+  roomTemperatureCelsius: number
+  coldHours: number
+  coldTemperatureCelsius: number
+}
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+export function buildFermentationTimeline(
+  form: FormState,
+  selectedPreset: PresetMetadata | undefined,
+  startedAt: Date = new Date(),
+): FermentationTimelineEntry[] {
+  const schedule = resolveFermentationTimeline(form, selectedPreset)
+  const timeline: FermentationTimelineEntry[] = []
+  let cursor = new Date(startedAt)
+
+  if (form.doughMethod === 'DIRECT') {
+    timeline.push(buildInstantEntry('mix', 'Mix dough', cursor))
+    cursor = appendFermentationStages(timeline, schedule, cursor)
+    timeline.push(buildInstantEntry('ready', 'Ready to bake', cursor))
+    return timeline
+  }
+
+  const prefermentLabel = form.doughMethod === 'POOLISH' ? 'poolish' : 'biga'
+
+  timeline.push(buildInstantEntry('mix-preferment', `Mix ${prefermentLabel}`, cursor))
+
+  if (schedule.roomHours > 0) {
+    const endAt = addHours(cursor, schedule.roomHours)
+    timeline.push(
+      buildDurationEntry(
+        'preferment-ferment',
+        `Ferment ${prefermentLabel}`,
+        cursor,
+        endAt,
+        schedule.roomHours,
+        schedule.roomTemperatureCelsius,
+      ),
+    )
+    cursor = endAt
+  }
+
+  timeline.push(buildInstantEntry('final-mix', 'Final mix', cursor))
+
+  if (schedule.coldHours > 0) {
+    const endAt = addHours(cursor, schedule.coldHours)
+    timeline.push(
+      buildDurationEntry(
+        'cold-ferment',
+        'Cold ferment',
+        cursor,
+        endAt,
+        schedule.coldHours,
+        schedule.coldTemperatureCelsius,
+      ),
+    )
+    cursor = endAt
+  }
+
+  timeline.push(buildInstantEntry('ready', 'Ready to bake', cursor))
+  return timeline
+}
+
+function appendFermentationStages(
+  timeline: FermentationTimelineEntry[],
+  schedule: ResolvedFermentationTimeline,
+  startedAt: Date,
+): Date {
+  let cursor = startedAt
+
+  if (schedule.roomHours > 0) {
+    const endAt = addHours(cursor, schedule.roomHours)
+    timeline.push(
+      buildDurationEntry(
+        'room-ferment',
+        'Room ferment',
+        cursor,
+        endAt,
+        schedule.roomHours,
+        schedule.roomTemperatureCelsius,
+      ),
+    )
+    cursor = endAt
+  }
+
+  if (schedule.coldHours > 0) {
+    const endAt = addHours(cursor, schedule.coldHours)
+    timeline.push(
+      buildDurationEntry(
+        'cold-ferment',
+        'Cold ferment',
+        cursor,
+        endAt,
+        schedule.coldHours,
+        schedule.coldTemperatureCelsius,
+      ),
+    )
+    cursor = endAt
+  }
+
+  return cursor
+}
+
+function resolveFermentationTimeline(
+  form: FormState,
+  selectedPreset: PresetMetadata | undefined,
+): ResolvedFermentationTimeline {
+  if (form.fermentationSchedule) {
+    return form.fermentationSchedule
+  }
+
+  const roomHours = selectedPreset?.roomHours ?? 0
+  const coldHours = selectedPreset?.coldHours ?? 0
+
+  return {
+    roomHours,
+    roomTemperatureCelsius: form.roomTemperatureCelsius,
+    coldHours,
+    coldTemperatureCelsius: form.coldTemperatureCelsius,
+  }
+}
+
+function buildInstantEntry(
+  key: string,
+  title: string,
+  date: Date,
+): FermentationTimelineEntry {
+  return {
+    key,
+    title,
+    timestamp: formatTimelineTimestamp(date),
+  }
+}
+
+function buildDurationEntry(
+  key: string,
+  title: string,
+  startedAt: Date,
+  endedAt: Date,
+  durationHours: number,
+  temperatureCelsius: number,
+): FermentationTimelineEntry {
+  return {
+    key,
+    title,
+    timestamp: formatTimelineTimestamp(endedAt),
+    durationLabel: `${formatHours(durationHours)} at ${formatTemperature(temperatureCelsius)}C`,
+    timeRangeLabel: `${formatTimelineTimestamp(startedAt)} to ${formatTimelineTimestamp(endedAt)}`,
+  }
+}
+
+function addHours(date: Date, hours: number): Date {
+  return new Date(date.getTime() + hours * 60 * 60 * 1000)
+}
+
+function formatTimelineTimestamp(date: Date): string {
+  return `${date.getDate()} ${MONTH_LABELS[date.getMonth()]} · ${formatClock(date)}`
+}
+
+function formatClock(date: Date): string {
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function formatHours(hours: number): string {
+  return `${trimTrailingZero(hours)}h`
+}
+
+function formatTemperature(value: number): string {
+  return trimTrailingZero(value)
+}
+
+function trimTrailingZero(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/, '')
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+export function getTimelineSummaryLabel(form: FormState): string {
+  return methodTimelineLabel(form.doughMethod)
+}
+
+function methodTimelineLabel(method: DoughMethod): string {
+  switch (method) {
+    case 'DIRECT':
+      return 'Direct dough flow'
+    case 'POOLISH':
+      return 'Poolish workflow'
+    case 'BIGA':
+      return 'Biga workflow'
+  }
+}


### PR DESCRIPTION
## Summary
- add a fermentation timeline panel that shows the step-by-step flow from mixing to bake
- support both preset and manual fermentation schedules with the same resolved values
- show durations and estimated timestamps for all applicable stages
- update the timeline instantly when the form changes
- refactor timeline stage construction to reduce duplication

## What Changed
- added a new `FermentationTimelinePanel` component in the results area
- added timeline computation utilities for:
  - direct dough flows
  - preferment workflows with `Final mix`
  - room and cold fermentation stages
- rendered full time ranges for fermentation stages so day transitions are visible
- covered the new behavior with unit and UI tests

## Timeline Behavior
- `DIRECT`
  - `Mix dough`
  - room and/or cold fermentation stages when applicable
  - `Ready to bake`
- `POOLISH` / `BIGA`
  - `Mix poolish` / `Mix biga`
  - preferment fermentation stage when room fermentation is present
  - `Final mix`
  - cold fermentation stage when applicable
  - `Ready to bake`

## Acceptance Criteria
- timeline renders all applicable stages including `mix`, fermentation, `final mix` when relevant, and `ready-to-bake`
- preset and manual schedules are resolved consistently
- durations and estimated timestamps are displayed
- timeline updates immediately on form changes without requiring calculate

## Validation
- `npm test`
- `npm run build`